### PR TITLE
Fix boolean filters

### DIFF
--- a/src/misc/arrayHelpers.ts
+++ b/src/misc/arrayHelpers.ts
@@ -39,6 +39,7 @@ export function filterArray(
         return false;
       }
       const currentIsMatched = dataFieldValue
+        .toString()
         .toLowerCase()
         .includes(fieldSearchText);
       return previousMatched || currentIsMatched;


### PR DESCRIPTION
Thank you for the library! When I try to use a filter for a boolean value, I receive the following error:
> a.toLowerCase is not a function

It turns out that the value is not being converted to a string before the toLowerCase call.