### PR TITLE
User Roles and Permissions (AUTH_GET_PERMISSIONS)

### DIFF
--- a/src/providers/AuthProvider.ts
+++ b/src/providers/AuthProvider.ts
@@ -1,7 +1,13 @@
 // import * as firebase from "firebase";
 import { FirebaseAuth } from "@firebase/auth-types";
 
-import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, AUTH_CHECK } from "react-admin";
+import {
+  AUTH_LOGIN,
+  AUTH_LOGOUT,
+  AUTH_ERROR,
+  AUTH_CHECK,
+  AUTH_GET_PERMISSIONS
+} from "react-admin";
 import { log, CheckLogging } from "../misc/logger";
 import { RAFirebaseOptions } from "./RAFirebaseOptions";
 import { FirebaseWrapper } from "./database/firebase/FirebaseWrapper";
@@ -69,6 +75,21 @@ class AuthClient {
       return null;
     }
   }
+
+  public async HandleGetPermissions() {
+    try {
+      const user = await this.getUserLogin();
+      // @ts-ignore
+      const token = await user.getIdTokenResult();
+
+      return token.claims;
+    } catch (e) {
+      log("HandleGetPermission: no user is logged in or tokenResult error", {
+        e
+      });
+      return null;
+    }
+  }
 }
 
 export function AuthProvider(firebaseConfig: {}, options: RAFirebaseOptions) {
@@ -90,6 +111,8 @@ export function AuthProvider(firebaseConfig: {}, options: RAFirebaseOptions) {
           return auth.HandleAuthCheck(params);
         case "AUTH_GETCURRENT":
           return auth.HandleGetCurrent();
+        case AUTH_GET_PERMISSIONS:
+          return auth.HandleGetPermissions();
         default:
           throw new Error("Unhandled auth type:" + type);
       }


### PR DESCRIPTION
The work that is done with this library is a great help for me to connect to my firebase backend.

There are a few parts missing which I encountered, like the possibility to work with user roles and react-admins `permissions` property in connection with the Firebase custom claims. I'm going to try to provide the missing parts which this first pull request.

About Firebase custom claims see:
https://medium.com/google-developers/controlling-data-access-using-firebase-auth-custom-claims-88b3c2c9352a
and https://firebase.google.com/docs/auth/admin/custom-claims


### Problem
My application does have different user roles and thereby I need to restrict access or disable some resources and views.
Todo so React-Admin provides a `permissions` prop which can be used to dynamically restrict access.
https://marmelab.com/react-admin/Authorization.html#restricting-access-to-resources-or-views

### Behavior
Returning a single child in the `<Admin />` component does only render the Login view. Every login attempt does automatically dispatch the `AUTH_LOGOUT`-action. 

```javascript
<Admin
       authProvider={authProvider}
       dataProvider={dataProvider}
       title="Memberarea"
        >
          {permissions => [
             <Resource
               create={MemberCreate}
               edit={MemberEdit}
               key={'member'}
               list={MemberList}
               name={'members'}
               options={{ label: 'Members' }}
             />,]}
</Admin>
```
![image](https://user-images.githubusercontent.com/10655255/61821100-bf373e80-ae56-11e9-80c7-81ae66f6b776.png)

### Solution
The `react-admin-firebase` `AuthProvider` does not implement the `AUTH_GET_PERMISSIONS`-action as needed to return the permissions to the reducer.
https://marmelab.com/react-admin/Authorization.html#configuring-the-auth-provider

### Pull request
I implemented the missing action action and added `HandleGetPermissions()` to extract the server side / backend provided user roles inside the Firebase User token as "claims". The implementation is running locally in my application very good and I can set the user roles with a Firebase function for a specific user.

Maybe you see other ways to provide user roles into react-admin but this seams to me the most forwards and in alignment with Firebase recommendation for user roles.

Happy to hear your feedback!

