### PR TITLE
Extend supported Firebase Authentication

### DIFF
--- a/src/providers/AuthProvider.ts
+++ b/src/providers/AuthProvider.ts
@@ -30,9 +30,9 @@ class AuthClient {
       if (mode === "link") {
         if (this.auth.isSignInWithEmailLink(window.location.href)) {
           user = await this.auth.signInWithEmailLink(
-        username,
+            username,
             window.location.href
-      );
+          );
 
           // Save email LocalStorage for same browser login
           window.localStorage.removeItem("emailForSignIn");
@@ -44,10 +44,8 @@ class AuthClient {
             window.location.hash;
           window.history.replaceState({}, document.title, urlWithoutParams);
 
-      log("HandleAuthLogin: user sucessfully logged in", { user });
+          log("HandleAuthLogin: user sucessfully logged in", { user });
         } else {
-          console.log("Login link request");
-
           const result: any = await this.auth.sendSignInLinkToEmail(username, {
             url: window.location.href,
             handleCodeInApp: true
@@ -75,7 +73,7 @@ class AuthClient {
     await this.auth.signOut();
   }
 
-  public async HandleAuthError(params) { }
+  public async HandleAuthError(params) {}
 
   public async HandleAuthCheck(params) {
     try {
@@ -89,7 +87,7 @@ class AuthClient {
 
   public async getUserLogin() {
     return new Promise((resolve, reject) => {
-      this.auth.onAuthStateChanged((user) => {
+      this.auth.onAuthStateChanged(user => {
         if (user) {
           resolve(user);
         } else {
@@ -154,7 +152,10 @@ export function AuthProvider(firebaseConfig: {}, options: RAFirebaseOptions) {
   };
 }
 
-function VerifyAuthProviderArgs(firebaseConfig: {}, options: RAFirebaseOptions) {
+function VerifyAuthProviderArgs(
+  firebaseConfig: {},
+  options: RAFirebaseOptions
+) {
   const hasNoApp = !options || !options.app;
   const hasNoConfig = !firebaseConfig;
   if (hasNoConfig && hasNoApp) {


### PR DESCRIPTION
This is a concept for extending and providing support for multiple Firebase authentication modes.

Default will still be `firebase.auth.signInWithEmailAndPassword()`, but this PR opens the possibility to write your own LoginPage-component which can pass a `mode` to the React-Admin LOGIN-action. Based on this mode different Firebase authentications will be possible.

In the first stepp I implement the mode `link`, which refers to Firebase "Email Link" authentication method. (Find out more here https://firebase.google.com/docs/auth/web/email-link-auth)

Open tasks / Bugs:
- [ ] Auth method "link": Provide option to configure `actionCodeSettings`-object
- [ ] Auth method "link": Display different text on the "login"-button based on link request or actual login
- [ ] Auth method "link": Show notification when success requested an email login
- [ ] Auth method "link": Prevent reload when requesting the login email
- [ ]  Implement more authentication methods

Let me know if you see issues or alternative ways to implmenet