### PR TITLE
Upgrade to react-admin v3 and remove ra-realtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "dependencies": {
     "firebase": "6.1.x",
     "path-browserify": "^1.0.0",
-    "ra-realtime": "^2.8.x",
     "react": "^16.x",
-    "react-admin": "^2.9.x",
+    "react-admin": "^3.0.2",
     "react-dom": "^16.x",
     "rxjs": "^6.5.x"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-import { RealtimeSaga } from "./providers/RealtimeSaga";
+// import { RealtimeSaga } from "./providers/RealtimeSaga";
 import { DataProvider } from "./providers/DataProvider";
 import { AuthProvider } from "./providers/AuthProvider";
-import { RAFirebaseOptions } from "./providers/RAFirebaseOptions";
+// import { RAFirebaseOptions } from "./providers/RAFirebaseOptions";
 
 export {
-  RealtimeSaga as FirebaseRealTimeSaga,
+  // RealtimeSaga as FirebaseRealTimeSaga,
   DataProvider as FirebaseDataProvider,
-  AuthProvider as FirebaseAuthProvider,
-  RAFirebaseOptions as RAFirebaseOptions
+  AuthProvider as FirebaseAuthProvider
+  // RAFirebaseOptions as RAFirebaseOptions
 };

--- a/src/providers/RAFirebaseOptions.ts
+++ b/src/providers/RAFirebaseOptions.ts
@@ -1,7 +1,7 @@
-export interface RAFirebaseOptions {
-  rootRef?: string;
-  app?: any;
-  logging?: boolean;
-  watch?: string[];
-  dontwatch?: string[];
-}
+// export interface RAFirebaseOptions {
+//   rootRef?: string;
+//   app?: any;
+//   logging?: boolean;
+//   watch?: string[];
+//   dontwatch?: string[];
+// }

--- a/src/providers/RealtimeSaga.ts
+++ b/src/providers/RealtimeSaga.ts
@@ -1,41 +1,45 @@
-import realtimeSaga from "ra-realtime";
-import { fb } from "./DataProvider";
-import { RAFirebaseOptions } from "index";
+// import realtimeSaga from "ra-realtime";
+// import { fb } from "./DataProvider";
+// import { RAFirebaseOptions } from "index";
 
-const observeRequest = (dataProvider, options?: RAFirebaseOptions) => (type, resource, params) => {
-  const safeOptions = options || {};
-  if (Array.isArray(safeOptions.watch)) {
-    const mustWatchResource = safeOptions.watch.includes(resource);
-    if (!mustWatchResource) {
-      return;
-    }
-  }
-  if (Array.isArray(safeOptions.dontwatch)) {
-    const mustNotWatchResource = safeOptions.dontwatch.includes(resource);
-    if (mustNotWatchResource) {
-      return;
-    }
-  }
+// const observeRequest = (dataProvider, options?: RAFirebaseOptions) => (
+//   type,
+//   resource,
+//   params
+// ) => {
+//   const safeOptions = options || {};
+//   if (Array.isArray(safeOptions.watch)) {
+//     const mustWatchResource = safeOptions.watch.includes(resource);
+//     if (!mustWatchResource) {
+//       return;
+//     }
+//   }
+//   if (Array.isArray(safeOptions.dontwatch)) {
+//     const mustNotWatchResource = safeOptions.dontwatch.includes(resource);
+//     if (mustNotWatchResource) {
+//       return;
+//     }
+//   }
 
-  return {
-    subscribe(observer) {
-      dataProvider(type, resource, params)
-        .then((results) => observer.next(results)) // New data received, notify the observer
-        .catch((error) => observer.error(error)); // Ouch, an error occured, notify the observer
+//   return {
+//     subscribe(observer) {
+//       dataProvider(type, resource, params)
+//         .then(results => observer.next(results)) // New data received, notify the observer
+//         .catch(error => observer.error(error)); // Ouch, an error occured, notify the observer
 
-      const subscription = {
-        unsubscribe() {
-          // Notify the saga that we cleaned up everything
-          // observer.complete();
-          // ^ THIS FAILS FRAMEWORK ISSUE
-        }
-      };
+//       const subscription = {
+//         unsubscribe() {
+//           // Notify the saga that we cleaned up everything
+//           // observer.complete();
+//           // ^ THIS FAILS FRAMEWORK ISSUE
+//         }
+//       };
 
-      return subscription;
-    }
-  };
-};
+//       return subscription;
+//     }
+//   };
+// };
 
-export function RealtimeSaga(dataProvider, options) {
-  return realtimeSaga(observeRequest(dataProvider, options));
-}
+// export function RealtimeSaga(dataProvider, options) {
+//   return realtimeSaga(observeRequest(dataProvider, options));
+// }


### PR DESCRIPTION
Got a first running test on `react-admin@v3` and basically only the `ra-realtime` needed to be handled, it has been removed on v3. 
https://github.com/marmelab/react-admin/pull/3908#issue-334448261

Besides that I didn't see any big issues. Will have a look regards the authentication soon.