### PR TITLE
fix result sorting in apiGetManyReference

### DIFF
--- a/src/providers/database/FirebaseClient.ts
+++ b/src/providers/database/FirebaseClient.ts
@@ -235,9 +235,9 @@ export class FirebaseClient implements IFirebaseClient {
     if (params.sort != null) {
       const { field, order } = params.sort;
       if (order === "ASC") {
-        sortArray(data, field, "asc");
+        sortArray(matches, field, "asc");
       } else {
-        sortArray(data, field, "desc");
+        sortArray(matches, field, "desc");
       }
     }
     const pageStart = (params.pagination.page - 1) * params.pagination.perPage;


### PR DESCRIPTION
In the data-provider code that handles GET_MANY_REFERENCE, the manual sort is not applied to the array that is being returned by the function.

This PR changes the sorting to use the correct field `matches`