### PR TITLE
Missing prepublish step caused pain with NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "build": "rm -rf dist && microbundle",
     "watch": "microbundle watch",
     "start-demo": "gulp start-demo",
-    "test": "jest --watchAll"
+    "test": "jest --watchAll",
+    "prepublish": "rm -rf dist && microbundle"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Trying to publish this package to my own NPM repo without having the build step in place meant that NPM kept committing the previous version of the compiled typescript