### PR TITLE
fixes soft deleting

### DIFF
--- a/src/providers/DataProvider.ts
+++ b/src/providers/DataProvider.ts
@@ -64,12 +64,14 @@ export function DataProvider(
           res = await fb.apiUpdateMany(resourceName, params);
           break;
         case DELETE:
-          if (options.softDelete) res = await fb.apiSoftDelete(resourceName, params);
-          res = await fb.apiDelete(resourceName, params);
+          if (options.softDelete)
+            res = await fb.apiSoftDelete(resourceName, params);
+          else res = await fb.apiDelete(resourceName, params);
           break;
         case DELETE_MANY:
-          if (options.softDelete) res = await fb.apiSoftDeleteMany(resourceName, params);
-          res = await fb.apiDeleteMany(resourceName, params);
+          if (options.softDelete)
+            res = await fb.apiSoftDeleteMany(resourceName, params);
+          else res = await fb.apiDeleteMany(resourceName, params);
           break;
         default:
           throw new Error(`Unknkown dataprovider command type: "${type}"`);


### PR DESCRIPTION
Looks like the changes in DataProvider.ts for soft deleting and a patch implemented just before adding soft deleting conflicted a bit and made it so that soft deleted documents were being destructively deleted immediately after.