### PR TITLE
Fix nested dates

### DIFF
--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -2,3 +2,4 @@ export * from './arrayHelpers';
 export * from './logger';
 export * from './messageTypes';
 export * from './pathHelper';
+export * from './timestamp-parser';

--- a/src/misc/timestamp-parser.ts
+++ b/src/misc/timestamp-parser.ts
@@ -1,0 +1,37 @@
+export function parseAllDatesDoc(obj: {}) {
+  const isObject = !!obj && typeof obj === 'object';
+  if (!isObject) {
+    return;
+  }
+  Object.keys(obj).map(key => {
+    const value = obj[key];
+    obj[key] = recusivelyCheckObjectValue(value);
+  });
+}
+
+export function recusivelyCheckObjectValue(input: any) {
+  const isFalsey = !input;
+  if (isFalsey) {
+    return input;
+  }
+  const isPrimitive = typeof input !== 'object';
+  if (isPrimitive) {
+    return input;
+  }
+  const isTimestamp = !!input.toDate && typeof input.toDate === 'function';
+  if (isTimestamp) {
+    return input.toDate();
+  }
+  const isArray = Array.isArray(input);
+  if (isArray) {
+    return input.map(value => recusivelyCheckObjectValue(value));
+  }
+  const isObject = typeof input === 'object';
+  if (isObject) {
+    Object.keys(input).map(key => {
+      const value = input[key];
+      input[key] = recusivelyCheckObjectValue(value);
+    });
+    return input;
+  }
+}

--- a/src/providers/database/ResourceManager.ts
+++ b/src/providers/database/ResourceManager.ts
@@ -7,7 +7,7 @@ import {
 import { RAFirebaseOptions } from "../RAFirebaseOptions";
 import { IFirebaseWrapper } from "./firebase/IFirebaseWrapper";
 import { User } from "@firebase/auth-types";
-import { log, getAbsolutePath, messageTypes, logError } from "../../misc";
+import { log, getAbsolutePath, messageTypes, logError, parseAllDatesDoc } from "../../misc";
 
 export interface IResource {
   path: string;
@@ -131,12 +131,7 @@ export class ResourceManager {
 
   private parseFireStoreDocument(doc: QueryDocumentSnapshot): {} {
     const data = doc.data();
-    Object.keys(data).forEach(key => {
-      const value = data[key];
-      if (value && value.toDate && value.toDate instanceof Function) {
-        data[key] = value.toDate();
-      }
-    });
+    parseAllDatesDoc(data);
     // React Admin requires an id field on every document,
     // So we can just using the firestore document id
     return { id: doc.id, ...data };

--- a/tests/integration-tests/ApiGetList.spec.ts
+++ b/tests/integration-tests/ApiGetList.spec.ts
@@ -26,7 +26,7 @@ describe("api methods", () => {
     expect(result.data.length).toBe(3);
   }, 100000);
 
-  test("FirebaseClient list docs", async () => {
+  test("FirebaseClient list docs with boolean filter", async () => {
     const testDocs = [
       {
         title: "A",

--- a/tests/integration-tests/ApiGetOne.spec.ts
+++ b/tests/integration-tests/ApiGetOne.spec.ts
@@ -18,10 +18,36 @@ describe("api methods", () => {
 
     const client = new FirebaseClient(fire, {});
     const result = await client.apiGetOne(collName, {
-      id: 'test22222',
+      id: "test22222",
     });
     expect(result.data).toBeTruthy();
-    expect(result.data['title']).toBe('ee');
-    expect(result.data['id']).toBe('test22222');
+    expect(result.data["title"]).toBe("ee");
+    expect(result.data["id"]).toBe("test22222");
+  }, 100000);
+
+  test("FirebaseClient apiGetOne, with nested Dates", async () => {
+    const collName = "list-mes";
+    const docId = "1234";
+    const collection = fire.db().collection(collName);
+    const testDocNestedDates = {
+      a: new Date("1999"),
+      b: {
+        b1: new Date("2006"),
+        c: {
+          c1: new Date("2006"),
+        },
+      },
+    };
+    await collection.doc(docId).set(testDocNestedDates);
+
+    const client = new FirebaseClient(fire, {});
+    const result = await client.apiGetOne(collName, {
+      id: docId,
+    });
+    const data = result.data as any;
+    expect(data).toBeTruthy();
+    expect(data.a).toBeInstanceOf(Date);
+    expect(data.b.b1).toBeInstanceOf(Date);
+    expect(data.b.c.c1).toBeInstanceOf(Date);
   }, 100000);
 });

--- a/tests/timestamp-parser.spec.ts
+++ b/tests/timestamp-parser.spec.ts
@@ -1,0 +1,75 @@
+import { parseAllDatesDoc, recusivelyCheckObjectValue } from "../src/misc";
+
+describe("timestamp-parser tests", () => {
+  test("retains number", () => {
+    const doc = null;
+    parseAllDatesDoc(doc);
+    expect(doc).toBe(null);
+  });
+
+  test("retains falsey", () => {
+    const doc = { a: null };
+    parseAllDatesDoc(doc);
+    expect(doc.a).toBe(null);
+  });
+
+  test("retains number", () => {
+    const doc = { a: 1 };
+    parseAllDatesDoc(doc);
+    expect(doc.a).toBe(1);
+  });
+
+  test("retains string", () => {
+    const doc = { a: "1" };
+    parseAllDatesDoc(doc);
+    expect(doc.a).toBe("1");
+  });
+
+  test("retains object", () => {
+    const doc = { a: { f: "1" } };
+    parseAllDatesDoc(doc);
+    expect(doc.a.f).toBe("1");
+  });
+
+  test("converts timestamp simple", () => {
+    const doc = { a: makeTimestamp() };
+    parseAllDatesDoc(doc);
+    expect(doc.a).toBeInstanceOf(Date);
+  });
+
+  test("converts timestamp deep nested", () => {
+    const doc = { a: { b: makeTimestamp(), c: { d: makeTimestamp() } } };
+    parseAllDatesDoc(doc);
+    expect(doc.a.b).toBeInstanceOf(Date);
+    expect(doc.a.c.d).toBeInstanceOf(Date);
+  });
+
+  test("converts timestamp array", () => {
+    const doc = { a: { c: [makeTimestamp(), makeTimestamp()] } };
+    parseAllDatesDoc(doc);
+    expect(doc.a.c[0]).toBeInstanceOf(Date);
+    expect(doc.a.c[1]).toBeInstanceOf(Date);
+  });
+
+  test("converts timestamp array", () => {
+    const doc = { a: { c: [{ d: makeTimestamp() }] } };
+    parseAllDatesDoc(doc);
+    expect(doc.a.c[0].d).toBeInstanceOf(Date);
+  });
+
+  test("retains falsey", () => {
+    const doc = ['okay'];
+    recusivelyCheckObjectValue(doc);
+    expect(doc[0]).toBe('okay');
+  });
+});
+
+function makeTimestamp() {
+  return new MockTimeStamp();
+}
+
+class MockTimeStamp {
+  toDate() {
+    return new Date();
+  }
+}


### PR DESCRIPTION
Fixes #108 
- Recursively parses fetched document and converts firestore `Timestamp` objects into `Date` objects
- Works for Dates in arrays, objects, deeply nested
- Added unit tests too