### PR TITLE
fixes soft-deleted item filtering

### DIFF
--- a/src/providers/database/FirebaseClient.ts
+++ b/src/providers/database/FirebaseClient.ts
@@ -52,7 +52,7 @@ export class FirebaseClient implements IFirebaseClient {
       }
     }
     let softDeleted = data;
-    if (this.options.softDelete) {
+    if (this.options.softDelete && !Object.keys(filterSafe).includes('deleted')) {
       softDeleted = data.filter(doc => !doc['deleted'])
     }
     const filteredData = filterArray(softDeleted, filterSafe);


### PR DESCRIPTION
In the README, it states
`  // NOTE: Hides 'deleted' records from list views unless overridden by filtering for {deleted: true} 
`
This functionality broke when the `sortArray` function was updated to include numbers and booleans. This PR changes one line that gets the functionality specified in the README working again 👍