### PR TITLE
Feature: Relative File paths options added

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const options = {
   // Instead of saving full download url for file, save just relative path and then get download url
   // when getting docs - main use case is handling multiple firebase projects (environments)
   // and moving/copying documents/storage files between them - with relativeFilePaths, download url
-  // always point to projects storage
+  // always point to project own storage
   relativeFilePaths: false 
 }
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ const options = {
   // Changes meta fields like 'createdby' and 'updatedby' to store user IDs instead of email addresses
   associateUsersById: false,
   // Casing for meta fields like 'createdby' and 'updatedby', defaults to 'lower', options are 'lower' | 'camel' | 'snake' | 'pascal' | 'kebab'
-  metaFieldCasing: 'lower'
+  metaFieldCasing: 'lower',
+  // Instead of saving full download url for file, save just relative path and then get download url
+  // when getting docs - main use case is handling multiple firebase projects (environments)
+  // and moving/copying documents/storage files between them - with relativeFilePaths, download url
+  // always point to projects storage
+  relativeFilePaths: false 
 }
 
 const dataProvider = FirebaseDataProvider(config, options);

--- a/src/misc/file-parser.ts
+++ b/src/misc/file-parser.ts
@@ -1,3 +1,6 @@
+import { logError } from "./logger";
+import { IFirebaseWrapper } from "../providers/database/firebase/IFirebaseWrapper";
+
 interface ParsedUpload {
   fieldDotsPath: string;
   fieldSlashesPath: string;
@@ -60,3 +63,43 @@ export function recusivelyParseObjectValue(
   });
   return input;
 }
+
+export const recursivelyMapStorageUrls = async (
+  fireWrapper: IFirebaseWrapper,
+  fieldValue: any
+): Promise<any> => {
+  const isArray = Array.isArray(fieldValue);
+  const isObject = !isArray && typeof fieldValue === "object";
+  const isFileField = isObject && !!fieldValue && fieldValue.hasOwnProperty("src");
+  if (isFileField) {
+    try {
+      const src = await fireWrapper.storage().ref(fieldValue.src).getDownloadURL();
+      return {
+        ...fieldValue,
+        src
+      };
+    } catch (error) {
+      logError(`Error when getting download URL`, {
+        error
+      });
+      return fieldValue;
+    }
+  } else if (isObject) {
+    for (let key in fieldValue) {
+      if (fieldValue.hasOwnProperty(key)) {
+        const value = fieldValue[key];
+        fieldValue[key] = await recursivelyMapStorageUrls(fireWrapper, value);
+      }
+    }
+
+    return fieldValue;
+  } else if (isArray) {
+    for (let i = 0; i < fieldValue.length; i++) {
+      fieldValue[i] = await recursivelyMapStorageUrls(fireWrapper, fieldValue[i])
+    }
+
+    return fieldValue;
+  }
+
+  return fieldValue;
+};

--- a/src/providers/RAFirebaseOptions.ts
+++ b/src/providers/RAFirebaseOptions.ts
@@ -11,4 +11,5 @@ export interface RAFirebaseOptions {
   softDelete?: boolean;
   associateUsersById?: boolean;
   metaFieldCasing?: 'lower' | 'camel' | 'snake' | 'pascal' | 'kebab';
+  relativeFilePaths?: boolean;
 }


### PR DESCRIPTION
### Description (from README):

Instead of saving full download url for file, save just relative path and then get download url when getting docs - main use case is handling multiple firebase projects (environments) and moving/copying documents/storage files between them - with relativeFilePaths, download url always point to project own storage