### PR TITLE
Add file name to storage path

### DIFF
--- a/src/providers/database/FirebaseClient.ts
+++ b/src/providers/database/FirebaseClient.ts
@@ -14,6 +14,7 @@ import {
   sortArray
 } from "../../misc";
 import { set } from "lodash";
+import path from 'path-browserify'
 
 export class FirebaseClient implements IFirebaseClient {
   private db: FirebaseFirestore;
@@ -461,7 +462,7 @@ export class FirebaseClient implements IFirebaseClient {
     docPath: string,
     fieldPath: string
   ): Promise<string> {
-    const storagePath = joinPaths(docPath, fieldPath);
+    const storagePath = path.join(docPath, fieldPath, rawFile.name);
     return await this.saveFile(storagePath, rawFile);
   }
 


### PR DESCRIPTION
Uploading files using `FileInput` and `ImageInput` currently results in files saved to Firebase Storage with an index value as their file name and no file suffix, e.g. `/posts/3643yMnapi6h7GxDrUyd/file/0`.

When the saved file is provided to the user as a FileField value, the UI shows the filename, however the file is downloaded with the index value as the file name (e.g. `0`). This is a poor user experience becuase the user is required to rename the file in oder to open it.

This PR adds the file name from the input's RawFile to the storage path so that the file is written to storage with a meaningful name. 