### PR TITLE
allow RAFirebaseOptions.rootRef to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const config = {
 // All options are optional
 const options = {
   // Use a different root document to set your resource collections, by default it uses the root collections of firestore
-  rootRef: 'root-collection/some-doc',
+  rootRef: 'root-collection/some-doc' | () => 'root-collection/some-doc',
   // Your own, previously initialized firebase app instance
   app: firebaseAppInstance,
   // Enable logging of react-admin-firebase

--- a/src/misc/pathHelper.ts
+++ b/src/misc/pathHelper.ts
@@ -1,13 +1,14 @@
 import path from 'path-browserify'
 
-export function getAbsolutePath(rootRef: string, relativePath: string): string {
+export function getAbsolutePath(rootRef: string | (() => string), relativePath: string): string {
   if (!rootRef) {
     return relativePath;
   }
   if (!relativePath) {
     throw new Error('Resource name must be a string of length greater than 0 characters');
   }
-  const withSlashes = path.join('/', rootRef, '/', relativePath, '/');
+  const rootRefValue = typeof(rootRef) === 'string' ? rootRef : rootRef()
+  const withSlashes = path.join('/', rootRefValue, '/', relativePath, '/');
   const slashCount = withSlashes.split("/").length - 1
   if (slashCount % 2) {
     throw new Error(`The rootRef path must point to a "document" not a "collection"

--- a/src/providers/RAFirebaseOptions.ts
+++ b/src/providers/RAFirebaseOptions.ts
@@ -1,5 +1,5 @@
 export interface RAFirebaseOptions {
-  rootRef?: string;
+  rootRef?: string | (() => string);
   app?: any;
   logging?: boolean;
   watch?: string[];

--- a/src/providers/database/ResourceManager.ts
+++ b/src/providers/database/ResourceManager.ts
@@ -101,7 +101,8 @@ export class ResourceManager {
     relativePath: string,
     collectionQuery?: messageTypes.CollectionQueryType
   ): Promise<void> {
-    const rootRef = this.options && this.options.rootRef;
+    const rf = this.options?.rootRef
+    const rootRef = rf == null ? null : typeof(rf) === 'string' ? rf : rf()
     const absolutePath = getAbsolutePath(rootRef, relativePath);
     const hasBeenInited = !!this.resources[relativePath];
     log("resourceManager.initPath()", {

--- a/src/providers/database/ResourceManager.ts
+++ b/src/providers/database/ResourceManager.ts
@@ -101,8 +101,7 @@ export class ResourceManager {
     relativePath: string,
     collectionQuery?: messageTypes.CollectionQueryType
   ): Promise<void> {
-    const rf = this.options?.rootRef
-    const rootRef = rf == null ? null : typeof(rf) === 'string' ? rf : rf()
+    const rootRef = this.options && this.options.rootRef;
     const absolutePath = getAbsolutePath(rootRef, relativePath);
     const hasBeenInited = !!this.resources[relativePath];
     log("resourceManager.initPath()", {

--- a/tests/Path.spec.ts
+++ b/tests/Path.spec.ts
@@ -28,3 +28,7 @@ test('path test - test incorrect rootRef', () => {
   }
   expect(run).toThrowError()
 });
+
+test('path test - function returns same results as string', () => {
+  expect(getAbsolutePath(() => 'root/doc', 'col1')).toBe(getAbsolutePath('root/doc', 'col1'))
+});

--- a/tests/integration-tests/ApiRootRef.spec.ts
+++ b/tests/integration-tests/ApiRootRef.spec.ts
@@ -7,9 +7,10 @@ test('rootref1', async () => {
   const rm = new ResourceManager(fire, {
     rootRef: 'root-ref1/ok'
   });
-  await fire.db().collection('root-ref1/ok/t1').add({test:''})
+  const docRef = await fire.db().collection('root-ref1/ok/t1').add({test:''})
   const r = await rm.TryGetResourcePromise('t1', null);
   const snap = await r.collection.get();
+  await docRef.delete()
   expect(snap.docs.length).toBe(1);
 }, 10000);
 
@@ -17,8 +18,9 @@ test('rootreffunction1', async () => {
   const rm = new ResourceManager(fire, {
     rootRef: () => 'root-ref-function1/ok'
   });
-  await fire.db().collection('root-ref-function1/ok/t1').add({test:''})
+  const docRef = await fire.db().collection('root-ref-function1/ok/t1').add({test:''})
   const r = await rm.TryGetResourcePromise('t1', null);
   const snap = await r.collection.get();
+  await docRef.delete()
   expect(snap.docs.length).toBe(1);
 }, 10000);

--- a/tests/integration-tests/ApiRootRef.spec.ts
+++ b/tests/integration-tests/ApiRootRef.spec.ts
@@ -12,3 +12,13 @@ test('rootref1', async () => {
   const snap = await r.collection.get();
   expect(snap.docs.length).toBe(1);
 }, 10000);
+
+test('rootreffunction1', async () => {
+  const rm = new ResourceManager(fire, {
+    rootRef: () => 'root-ref-function1/ok'
+  });
+  await fire.db().collection('root-ref-function1/ok/t1').add({test:''})
+  const r = await rm.TryGetResourcePromise('t1', null);
+  const snap = await r.collection.get();
+  expect(snap.docs.length).toBe(1);
+}, 10000);


### PR DESCRIPTION
Allowing RAFirebaseOptions.rootRef to be a function returning a string allows for dynamic scoping of documents. Useful if we want to dynamically scope it per logged in user rather than to a static collection/document