### PR TITLE
Allow array in filters

### DIFF
--- a/src/misc/arrayHelpers.ts
+++ b/src/misc/arrayHelpers.ts
@@ -87,5 +87,9 @@ export function doesRowMatch(
   if (isBooleanOrNumber) {
     return searchThis === searchValue;
   }
+  const isArraySearch = Array.isArray(searchValue);
+  if (isArraySearch) {
+    return searchValue.includes(searchThis);
+  }
   return false;
 }

--- a/src/misc/objectFlatten.ts
+++ b/src/misc/objectFlatten.ts
@@ -1,4 +1,5 @@
-type SearchValue = {} | number | string | boolean | null;
+type SearchValues = {} | number | string | boolean | null ;
+type SearchValue = SearchValues | SearchValue[];
 
 export interface SearchObj {
   searchField: string;

--- a/src/providers/lazy-loading/paramsToQuery.ts
+++ b/src/providers/lazy-loading/paramsToQuery.ts
@@ -46,9 +46,9 @@ export function filtersToQuery(
   query: FireStoreQuery,
   filters: { [fieldName: string]: any }
 ): FireStoreQuery {
-  const res = Object.keys(filters).reduce((acc, fieldName) => {
-    acc.where(fieldName, '==', filters[fieldName]);
-    return acc;
+  const res = Object.entries(filters).reduce((acc,[fieldName, fieldValue]) => {
+    const opStr = fieldValue && Array.isArray(fieldValue) ? 'in' : '==';
+    return acc.where(fieldName, opStr, fieldValue);
   }, query);
   return res;
 }


### PR DESCRIPTION
Firebase now supports array filters (  `where('field', 'in', ['a','b','c'])`  ). 
This PR updates dependencies and allows filter values to be an array, where `in` will be used instead of `==`