### PR TITLE
Fix "null" username  & avatar in AppBar UserMenu after firebase auth login

### DIFF
--- a/src/providers/AuthProvider.ts
+++ b/src/providers/AuthProvider.ts
@@ -116,8 +116,8 @@ class AuthClient {
       const { uid, displayName, photoURL } = await this.getUserLogin();
       const identity: UserIdentity = {
         id: uid,
-        fullName: displayName + '',
-        avatar: photoURL + '',
+        fullName: `${displayName ?? ''}`,
+        avatar: `${photoURL ?? ''}`,
       };
       return identity;
     } catch (e) {


### PR DESCRIPTION
**Fix in `HandleGetIdentity()`:** leave fullName & avatar as empty strings (instead of `"null"`) when coming as `null` from `getUserLogin()`, as right now whatever value they have gets converted to string


|Before the fix|![image](https://user-images.githubusercontent.com/28148619/117846904-40dca400-b258-11eb-8ed2-4918084739a4.png)|
|-------------|------------|
|With the fix|![image](https://user-images.githubusercontent.com/28148619/117846075-7af97600-b257-11eb-9c5c-23d2d987ee9b.png)|

(check top right corner)

Now, as expected, react-admin shows just a button with the user icon for the UserMenu when these values come empty from firebase.

Tested using the demo project with `yarn start-demo`