### PR TITLE
Add transformToDb option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ const options = {
   firestoreCostsLogger: {
     enabled: false,
     localStoragePrefix // optional
-  }
+  },
+  // Function to transform documents before they are written to Firestore
+  transformToDb: (resourceName, document, documentId) => document
 }
 
 const dataProvider = FirebaseDataProvider(config, options);

--- a/src/providers/commands/Create.ts
+++ b/src/providers/commands/Create.ts
@@ -28,11 +28,12 @@ export async function Create<T extends ra.Record>(
     client.checkRemoveIdField(docObj, overridenId);
     await client.addCreatedByFields(docObj);
     await client.addUpdatedByFields(docObj);
+    const docObjTransformed = client.transformToDb(resourceName, docObj, overridenId);
     log("Create", { docObj });
-    await r.collection.doc(overridenId).set(docObj, { merge: false });
+    await r.collection.doc(overridenId).set(docObjTransformed, { merge: false });
     return {
       data: {
-        ...data,
+        ...docObjTransformed,
         id: overridenId,
       },
     };
@@ -43,10 +44,11 @@ export async function Create<T extends ra.Record>(
   client.checkRemoveIdField(docObj, newId);
   await client.addCreatedByFields(docObj);
   await client.addUpdatedByFields(docObj);
-  await r.collection.doc(newId).set(docObj, { merge: false });
+  const docObjTransformed = client.transformToDb(resourceName, docObj, newId);
+  await r.collection.doc(newId).set(docObjTransformed, { merge: false });
   return {
     data: {
-      ...data,
+      ...docObjTransformed,
       id: newId,
     },
   };

--- a/src/providers/commands/Update.ts
+++ b/src/providers/commands/Update.ts
@@ -17,7 +17,8 @@ export async function Update<T extends ra.Record>(
   const docObj = { ...data };
   client.checkRemoveIdField(docObj, id);
   await client.addUpdatedByFields(docObj);
-  await r.collection.doc(id).update(docObj);
+  const docObjTransformed = client.transformToDb(resourceName, docObj, id);
+  await r.collection.doc(id).update(docObjTransformed);
   return {
     data: {
       ...data,

--- a/src/providers/commands/UpdateMany.ts
+++ b/src/providers/commands/UpdateMany.ts
@@ -20,9 +20,10 @@ export async function UpdateMany(
       const docObj = { ...data };
       client.checkRemoveIdField(docObj, idStr);
       await client.addUpdatedByFields(docObj);
+      const docObjTransformed = client.transformToDb(resourceName, docObj, idStr);
       await r.collection
         .doc(idStr)
-        .update(docObj);
+        .update(docObjTransformed);
       return {
         ...data,
         id: idStr

--- a/src/providers/database/FireClient.ts
+++ b/src/providers/database/FireClient.ts
@@ -32,6 +32,13 @@ export class FireClient {
     }
   }
 
+  public transformToDb(resourceName: string, document: any, docId: string): any {
+    if (typeof this.options.transformToDb === 'function') {
+      return this.options.transformToDb(resourceName, document, docId);
+    }
+    return document;
+  }
+
   public async parseDataAndUpload(r: IResource, id: string, data: any) {
     if (!data) {
       return data;

--- a/src/providers/options.ts
+++ b/src/providers/options.ts
@@ -45,6 +45,8 @@ export interface RAFirebaseOptions {
     enabled: boolean;
     persistCount?: boolean;
   };
+  // Function to transform documents before they are written to Firestore
+  transformToDb?: (resourceName: string, document: any, documentId: string) => any;
   /* OLD FLAGS */
   /**
    * @deprecated The method should not be used

--- a/tests/integration-tests/ApiCreate.spec.ts
+++ b/tests/integration-tests/ApiCreate.spec.ts
@@ -28,4 +28,40 @@ describe("ApiCreate", () => {
 
     expect(first.hasOwnProperty('MY_CREATED_BY')).toBeTruthy();
   }, 100000);
+  test("FireClient create doc with transformToDb function provided", async () => {
+    const client = MakeMockClient({
+      logging: true,
+      transformToDb: (resourceName, document, id) => {
+        if (resourceName === "users") {
+          return {
+            ...document,
+            firstName: document.firstName.toUpperCase(),
+            picture: document.picture.src || document.picture,
+          };
+        }
+        return document;
+      }
+    });
+
+    const newUser = { 
+      firstName: "John",
+      lastName: "Last",
+      age: 20,
+      picture: {
+        src: "http://example.com/pic.png"
+      },
+    };
+
+    await Create("users", { data: newUser }, client);
+    const users = await getDocsFromCollection(client.db(), "users");
+
+    expect(users.length).toBe(1);
+    expect(users[0]).toMatchObject({
+      firstName: "JOHN",
+      lastName: "Last",
+      age: 20,
+      picture: "http://example.com/pic.png",
+    });
+
+  }, 100000);
 });

--- a/tests/integration-tests/ApiUpdateMany.spec.ts
+++ b/tests/integration-tests/ApiUpdateMany.spec.ts
@@ -5,14 +5,14 @@ describe("api methods", () => {
   test("FireClient updatemany doc", async () => {
     const client = MakeMockClient({ softDelete: true, disableMeta: true });
     const docIds = ["test123", "test22222", "asdads"];
-    const collName = "updatec";
-    const collection = client.db().collection(collName);
+    const collectionName = "updatec";
+    const collection = client.db().collection(collectionName);
     await Promise.all(
       docIds.map((id) => collection.doc(id).set({ title: "ee" }))
     );
 
     await UpdateMany(
-      collName,
+      collectionName,
       { ids: docIds, data: { title: "blue" } as any },
       client
     );
@@ -21,5 +21,49 @@ describe("api methods", () => {
     expect(res.docs[0].get("title")).toBe("blue");
     expect(res.docs[1].get("title")).toBe("blue");
     expect(res.docs[2].get("title")).toBe("blue");
+  }, 100000);
+
+  test("FireClient updatemany doc with transformToDb function provided", async () => {
+    const collectionName = "updatec";
+
+    const client = MakeMockClient({
+      transformToDb: (resourceName, document, id) => {
+        if (resourceName === collectionName) {
+          return {
+            ...document,
+            title: document.title.toUpperCase(),
+          };
+        }
+        return document;
+      }
+    });
+
+    const docIds = ["test123", "test22222", "asdads"];
+    const collection = client.db().collection(collectionName);
+
+    const originalDoc = {
+      title: "red",
+      body: "Hello world...",
+    };
+    const updatedDoc = {
+      title: "blue",
+      body: "OK...",
+    };
+
+    await Promise.all(
+      docIds.map((id) => collection.doc(id).set(originalDoc))
+    );
+
+    await UpdateMany(
+      collectionName,
+      { ids: docIds, data: updatedDoc },
+      client
+    );
+
+    const res = await collection.get();
+    expect(res.docs.length).toBe(3);
+    expect(res.docs[0].get("title")).toBe("BLUE");
+    expect(res.docs[1].get("title")).toBe("BLUE");
+    expect(res.docs[2].get("title")).toBe("BLUE");
   }, 100000);
 });


### PR DESCRIPTION
Adds a new option `transformToDb` which is a function that transforms documents before they're written to Firestore.

My use case for this is to transform an updated file field from `{ src: "url" }` to just a string containing the url. Without this transformToDb option I have to wrap the dataProvider create/update functions and do a second update with the transformed doc after calling the base create/update function.

Also added some test cases.

Closes #197