### PR TITLE
Refactor: Centralize firebase types to make upgrading firebase sdk easier

### DIFF
--- a/.github/workflows/push_deploy.yml
+++ b/.github/workflows/push_deploy.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Use Node.js 10.17
+      - name: Use Node.js 12.22.8
         uses: actions/setup-node@v1
         with:
-          node-version: 10.17
+          node-version: 12.22.8
       - name: Cache node_modules
         id: cache-modules
         uses: actions/cache@v1
@@ -19,11 +19,11 @@ jobs:
           key: ${{ runner.OS }}-push_deploy-${{ hashFiles('package.json') }}
       - name: Install Dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
-        run: npm install
+        run: yarn install --pure-lockfile
       - name: Check Build
-        run: npm run-script build
+        run: yarn build
       - name: Check Tests
-        run: npm run-script test
+        run: yarn test
       - name: Deploy to npm! 🚀 (if master branch)
         if: github.ref == 'refs/heads/master'
         uses: benwinding/merge-release@master

--- a/package.json
+++ b/package.json
@@ -15,11 +15,8 @@
     "rxjs": "^6.5.x"
   },
   "devDependencies": {
-    "@firebase/app-types": "^0.3.9",
-    "@firebase/auth-types": "^0.6.0",
     "@firebase/firestore-types": "1.2.0",
     "@firebase/testing": "^0.19.1",
-    "@firebase/util": "^0.2.11",
     "@types/firebase": "^3.2.1",
     "@types/jest": "^24.0.13",
     "@types/lodash": "^4.14.150",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,14 @@
     "microbundle": "^0.12.4",
     "ts-jest": "^25",
     "tslint": "^5.16.0",
-    "typescript": "^4.1.x"
+    "typescript": "4.5.5"
   },
   "homepage": "https://github.com/benwinding/react-admin-firebase",
   "email": "hello@benwinding.com",
   "license": "MIT",
   "scripts": {
     "build": "rm -rf dist && microbundle",
+    "tsc-test": "tsc -p ./tsconfig.spec.json",
     "watch": "microbundle watch",
     "start-demo": "gulp start-demo",
     "start-emulator": "yarn firebase emulators:start --only firestore",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "react-admin-firebase",
   "description": "A firebase data provider for the React Admin framework",
-  "version": "3.2.16",
+  "version": "3.9.0",
   "peerDependencies": {
-    "firebase": "^7.9.x",
+    "firebase": "^9.6.4",
     "react": "^17.x",
     "react-admin": "^3.x",
     "react-dom": "^17.x",
@@ -15,8 +15,7 @@
     "rxjs": "^6.5.x"
   },
   "devDependencies": {
-    "@firebase/firestore-types": "1.2.0",
-    "@firebase/testing": "^0.19.1",
+    "@firebase/testing": "^0.20.11",
     "@types/firebase": "^3.2.1",
     "@types/jest": "^24.0.13",
     "@types/lodash": "^4.14.150",

--- a/src/misc/document-parser.ts
+++ b/src/misc/document-parser.ts
@@ -1,7 +1,7 @@
-import { QueryDocumentSnapshot } from '@firebase/firestore-types';
+import { FireStoreDocumentSnapshot, FireStoreQueryDocumentSnapshot } from './firebase-models';
 import { parseAllDatesDoc } from './timestamp-parser';
 
-export const parseFireStoreDocument = (doc: QueryDocumentSnapshot) => {
+export const parseFireStoreDocument = (doc: FireStoreQueryDocumentSnapshot) => {
   const data = doc.data();
   parseAllDatesDoc(data);
   // React Admin requires an id field on every document,

--- a/src/misc/file-parser.ts
+++ b/src/misc/file-parser.ts
@@ -76,10 +76,8 @@ export const recursivelyMapStorageUrls = async (
     if (isAlreadyUploaded) {
       return fieldValue;
     }
-    let ref: firebase.storage.Reference = null as any;
     try {
-      ref = fireWrapper.storage().ref(fieldValue.src);
-      const src = await ref.getDownloadURL();
+      const src = await fireWrapper.getStorageDownloadUrl(fieldValue.src);
       return {
         ...fieldValue,
         src
@@ -88,7 +86,6 @@ export const recursivelyMapStorageUrls = async (
       logError(`Error when getting download URL`, {
         error,
         fieldValue,
-        ref
       });
       return fieldValue;
     }

--- a/src/misc/firebase-models.ts
+++ b/src/misc/firebase-models.ts
@@ -1,10 +1,3 @@
-import { 
-  DocumentSnapshot, 
-  Query,
-  QueryDocumentSnapshot,
-  OrderByDirection
-} from '@firebase/firestore-types';
-
 export type FireUser = firebase.User;
 export type FireApp = firebase.app.App;
 
@@ -25,8 +18,9 @@ export type FireStore = firebase.firestore.Firestore;
 export type FireStoreBatch = firebase.firestore.WriteBatch;
 export type FireStoreTimeStamp = firebase.firestore.FieldValue;
 export type FireStoreDocumentRef = firebase.firestore.DocumentReference;
-export type FireStoreDocumentSnapshot = DocumentSnapshot;
+export type FireStoreDocumentSnapshot = firebase.firestore.DocumentSnapshot<firebase.firestore.DocumentData>;
 export type FireStoreCollectionRef = firebase.firestore.CollectionReference;
-export type FireStoreQueryDocumentSnapshot = QueryDocumentSnapshot;
-export type FireStoreQuery = Query;
-export type FireStoreQueryOrder = OrderByDirection;
+export type FireStoreQueryDocumentSnapshot = firebase.firestore.QueryDocumentSnapshot;
+export type FireStoreQuery = firebase.firestore.Query;
+export type FireStoreQueryOrder = firebase.firestore.OrderByDirection;
+

--- a/src/misc/firebase-models.ts
+++ b/src/misc/firebase-models.ts
@@ -1,0 +1,32 @@
+import { 
+  DocumentSnapshot, 
+  Query,
+  QueryDocumentSnapshot,
+  OrderByDirection
+} from '@firebase/firestore-types';
+
+export type FireUser = firebase.User;
+export type FireApp = firebase.app.App;
+
+export type FireStorage = firebase.storage.Storage;
+export type FireStorageReference = firebase.storage.Reference;
+export type FireUploadTaskSnapshot = firebase.storage.UploadTaskSnapshot;
+export type FireUploadTask = firebase.storage.UploadTask;
+export type FireStoragePutFileResult = {
+  task: FireUploadTask, 
+  taskResult: Promise<FireUploadTaskSnapshot>,
+  downloadUrl: Promise<string>,
+}
+
+export type FireAuth = firebase.auth.Auth;
+export type FireAuthUserCredentials = firebase.auth.UserCredential;
+
+export type FireStore = firebase.firestore.Firestore;
+export type FireStoreBatch = firebase.firestore.WriteBatch;
+export type FireStoreTimeStamp = firebase.firestore.FieldValue;
+export type FireStoreDocumentRef = firebase.firestore.DocumentReference;
+export type FireStoreDocumentSnapshot = DocumentSnapshot;
+export type FireStoreCollectionRef = firebase.firestore.CollectionReference;
+export type FireStoreQueryDocumentSnapshot = QueryDocumentSnapshot;
+export type FireStoreQuery = Query;
+export type FireStoreQueryOrder = OrderByDirection;

--- a/src/misc/messageTypes.ts
+++ b/src/misc/messageTypes.ts
@@ -1,5 +1,4 @@
-// Firebase types
-import { CollectionReference } from "@firebase/firestore-types";
+import { FireStoreCollectionRef } from "./firebase-models";
 import { GetListParams } from "./react-admin-models";
 
 // PARAMETERS
@@ -7,8 +6,8 @@ export namespace messageTypes {
   export type IParamsGetList = GetListParams;
 
   export type CollectionQueryType = (
-    arg0: CollectionReference
-  ) => CollectionReference;
+    arg0: FireStoreCollectionRef
+  ) => FireStoreCollectionRef;
 
   export interface IParamsGetOne {
     id: string;

--- a/src/misc/objectFlatten.ts
+++ b/src/misc/objectFlatten.ts
@@ -1,10 +1,12 @@
+type SearchValue = {} | number | string | boolean | null;
+
 export interface SearchObj {
   searchField: string;
-  searchValue: number | string | boolean | null;
+  searchValue: SearchValue;
 }
 export function getFieldReferences(
   fieldName: string,
-  value: {} | number | string | boolean | null
+  value: {} | SearchValue
 ): SearchObj[] {
   const isFalsy = !value;
   const isSimple = isFalsy ||
@@ -16,11 +18,11 @@ export function getFieldReferences(
     return [
       {
         searchField: fieldName,
-        searchValue: value as number | string | boolean | null,
+        searchValue: value as SearchValue,
       },
     ];
   }
-  const tree = {} as any;
+  const tree = {} as Record<string, SearchValue>;
   tree[fieldName] = value;
   return objectFlatten(tree);
 }

--- a/src/providers/DataProvider.ts
+++ b/src/providers/DataProvider.ts
@@ -9,7 +9,7 @@ import {
 import * as ra from "../misc/react-admin-models";
 import { RAFirebaseOptions } from "./options";
 import { FirebaseWrapper } from "./database/firebase/FirebaseWrapper";
-import { FireApp } from "./database/firebase/IFirebaseWrapper";
+import { FireApp } from "../misc/firebase-models";
 import { FireClient } from "./database/FireClient";
 import { GetList, GetMany, GetManyReference, GetOne } from "./queries";
 import { Create, Delete, DeleteMany, Update, UpdateMany } from "./commands";
@@ -34,8 +34,7 @@ export function DataProvider(
     options
   });
 
-  const fireWrapper = new FirebaseWrapper();
-  fireWrapper.init(firebaseConfig, optionsInput);
+  const fireWrapper = new FirebaseWrapper(optionsInput, firebaseConfig);
 
   async function run<T>(cb: () => Promise<T>) {
     let res: any;
@@ -43,7 +42,7 @@ export function DataProvider(
       res = await cb();
       return res;
     } catch (error) {
-      const errorMsg = error.toString();
+      const errorMsg = ((error as any) || '').toString();
       const code = retrieveStatusCode(errorMsg);
       const errorObj = { status: code, message: errorMsg, json: res };
       logError("DataProvider:", error, { errorMsg, code, errorObj });

--- a/src/providers/commands/Create.ts
+++ b/src/providers/commands/Create.ts
@@ -37,7 +37,7 @@ export async function Create<T extends ra.Record>(
       },
     };
   }
-  const newId = fireWrapper.db().collection("collections").doc().id;
+  const newId = fireWrapper.dbMakeNewId();
   const data = await client.parseDataAndUpload(r, newId, params.data);
   const docObj = { ...data };
   client.checkRemoveIdField(docObj, newId);

--- a/src/providers/commands/Delete.ts
+++ b/src/providers/commands/Delete.ts
@@ -18,7 +18,7 @@ export async function Delete<T extends ra.Record>(
     const id = params.id + "";
     await r.collection.doc(id).delete();
   } catch (error) {
-    throw new Error(error);
+    throw new Error(error as any);
   }
   return {
     data: params.previousData as T,

--- a/src/providers/commands/DeleteMany.ts
+++ b/src/providers/commands/DeleteMany.ts
@@ -3,8 +3,6 @@ import { log } from "../../misc";
 import * as ra from "../../misc/react-admin-models";
 import { DeleteManySoft } from "./DeleteMany.Soft";
 
-type DocumentRef = firebase.firestore.DocumentReference<any>;
-
 export async function DeleteMany(
   resourceName: string,
   params: ra.DeleteManyParams,
@@ -17,17 +15,17 @@ export async function DeleteMany(
   const r = await rm.TryGetResource(resourceName);
   log("DeleteMany", { resourceName, resource: r, params });
   const returnData: ra.Identifier[] = [];
-  const batch = fireWrapper.db().batch();
+  const batch = fireWrapper.dbCreateBatch();
   for (const id of params.ids) {
     const idStr = id + '';
-    const docToDelete = r.collection.doc(idStr) as DocumentRef;
+    const docToDelete = r.collection.doc(idStr);
     batch.delete(docToDelete);
     returnData.push(id);
   }
   try {
     await batch.commit();
   } catch (error) {
-    throw new Error(error)
+    throw new Error(error as any)
   }
   return { data: returnData };
 }

--- a/src/providers/database/ResourceManager.ts
+++ b/src/providers/database/ResourceManager.ts
@@ -8,7 +8,7 @@ import {
   logWarn,
   IFirestoreLogger,
 } from '../../misc';
-import { FireStoreCollectionRef, FireStoreDocumentRef, FireStoreDocumentSnapshot, FireStoreQueryDocumentSnapshot } from 'misc/firebase-models';
+import { FireStoreCollectionRef, FireStoreDocumentSnapshot, FireStoreQueryDocumentSnapshot } from 'misc/firebase-models';
 
 export interface IResource {
   path: string;
@@ -105,7 +105,7 @@ export class ResourceManager {
     await this.initPath(relativePath);
     const resource = this.GetResource(relativePath);
     this.flogger.logDocument(1)();
-    const docSnap: FireStoreDocumentSnapshot = await resource.collection.doc(docId).get();
+    const docSnap = await resource.collection.doc(docId).get();
     if (!docSnap.exists) {
       throw new Error('react-admin-firebase: No id found matching: ' + docId);
     }

--- a/src/providers/database/firebase/FirebaseWrapper.ts
+++ b/src/providers/database/firebase/FirebaseWrapper.ts
@@ -1,55 +1,52 @@
-import { FireApp, IFirebaseWrapper } from './IFirebaseWrapper';
+import {
+  IFirebaseWrapper,
+} from './IFirebaseWrapper';
 
-import firebase, { User } from 'firebase/app';
+import firebase from 'firebase/app';
 import 'firebase/firestore';
 import 'firebase/auth';
 import 'firebase/storage';
+
 import { log } from 'misc';
 import { RAFirebaseOptions } from 'providers/options';
+import {
+  FireApp,
+  FireAuth,
+  FireAuthUserCredentials,
+  FireStorage,
+  FireStoragePutFileResult,
+  FireStore,
+  FireStoreBatch,
+  FireStoreCollectionRef,
+  FireUploadTaskSnapshot,
+  FireUser
+} from 'misc/firebase-models';
 
 export class FirebaseWrapper implements IFirebaseWrapper {
-  private firestore: firebase.firestore.Firestore = null as any;
-  private app: FireApp = null as any;
-  public options: RAFirebaseOptions = {};
+  private firestore: FireStore;
+  private app: FireApp;
+  public options: RAFirebaseOptions;
 
-  public GetApp(): FireApp {
-    return this.app;
-  }
-
-  constructor() {}
-
-  public init(firebaseConfig: {}, options?: RAFirebaseOptions): void {
-    const optionsSafe = options || {};
+  constructor(
+    inputOptions: RAFirebaseOptions | undefined,
+    firebaseConfig: {},
+  ) { 
+    const optionsSafe = inputOptions || {};
     this.options = optionsSafe;
     this.app = ObtainFirebaseApp(firebaseConfig, optionsSafe);
     this.firestore = this.app.firestore();
   }
-  public db(): firebase.firestore.Firestore {
-    return this.firestore;
+  dbGetCollection(absolutePath: string): FireStoreCollectionRef {
+    return this.firestore.collection(absolutePath);
   }
-  public serverTimestamp() {
-    // This line doesn't work for some reason, might be firebase sdk.
-    // return firebase.firestore.FieldValue.serverTimestamp();
-    return new Date();
+  dbCreateBatch(): FireStoreBatch {
+    return this.firestore.batch();
   }
-  public auth() {
-    return this.app.auth() as any;
+  dbMakeNewId(): string {
+    return this.firestore.collection("collections").doc().id
   }
-  public storage() {
-    return this.app.storage();
-  }
-  public async GetUserLogin(): Promise<User> {
-    return new Promise((resolve, reject) => {
-      this.app.auth().onAuthStateChanged((user) => {
-        if (user) {
-          resolve(user);
-        } else {
-          reject('getUserLogin() no user logged in');
-        }
-      });
-    });
-  }
-  public OnUserLogout(callBack: (u: firebase.User | null) => any) {
+
+  public OnUserLogout(callBack: (u: FireUser | null) => any) {
     this.app.auth().onAuthStateChanged((user) => {
       const isLoggedOut = !user;
       log('FirebaseWrapper.OnUserLogout', { user, isLoggedOut });
@@ -57,6 +54,88 @@ export class FirebaseWrapper implements IFirebaseWrapper {
         callBack(user);
       }
     });
+  }
+  putFile(storagePath: string, rawFile: any): FireStoragePutFileResult {
+    const task = this.app.storage().ref(storagePath).put(rawFile);
+    const taskResult = new Promise<FireUploadTaskSnapshot>(
+      (res, rej) => task.then(res).catch(rej)
+    );
+    const downloadUrl = taskResult.then(t => t.ref.getDownloadURL()).then(url => url as string)
+    return {
+      task,
+      taskResult,
+      downloadUrl,
+    }
+  }
+  async getStorageDownloadUrl(fieldSrc: string): Promise<string> {
+    return this.app.storage().ref(fieldSrc).getDownloadURL();
+  }
+  public serverTimestamp() {
+    // This line doesn't work for some reason, might be firebase sdk.
+    return firebase.firestore.FieldValue.serverTimestamp();
+  }
+  async authSetPersistence(persistenceInput: 'session' | 'local' | 'none') {
+    let persistenceResolved: string;
+    switch (persistenceInput) {
+      case 'local':
+        persistenceResolved = firebase.auth.Auth.Persistence.LOCAL;
+        break;
+      case 'none':
+        persistenceResolved = firebase.auth.Auth.Persistence.NONE;
+        break;
+      case 'session':
+      default:
+        persistenceResolved = firebase.auth.Auth.Persistence.SESSION;
+        break;
+    }
+    log('setPersistence', { persistenceInput, persistenceResolved });
+    return this.app.auth()
+      .setPersistence(persistenceResolved)
+      .catch((error) => console.error(error));
+  }
+  async authSigninEmailPassword(email: string, password: string): Promise<FireAuthUserCredentials> {
+    const user = await this.app.auth().signInWithEmailAndPassword(
+      email,
+      password
+    );
+    return user;
+  }
+  async authSignOut(): Promise<void> {
+    return this.app.auth().signOut();
+  }
+  async authGetUserLoggedIn(): Promise<FireUser> {
+    return new Promise((resolve, reject) => {
+      const auth = this.app.auth();
+      if (auth.currentUser) return resolve(auth.currentUser);
+      const unsubscribe = this.app.auth().onAuthStateChanged((user) => {
+        unsubscribe();
+        if (user) {
+          resolve(user);
+        } else {
+          reject();
+        }
+      });
+    });
+  }
+  public async GetUserLogin(): Promise<FireUser> {
+    return this.authGetUserLoggedIn();
+  }
+
+  /** @deprecated */
+  public auth(): FireAuth {
+    return this.app.auth();
+  }
+  /** @deprecated */
+  public storage(): FireStorage {
+    return this.app.storage();
+  }
+  /** @deprecated */
+  public GetApp(): FireApp {
+    return this.app;
+  }
+  /** @deprecated */
+  public db(): FireStore {
+    return this.firestore;
   }
 }
 

--- a/src/providers/database/firebase/IFirebaseWrapper.ts
+++ b/src/providers/database/firebase/IFirebaseWrapper.ts
@@ -1,17 +1,43 @@
 import { RAFirebaseOptions } from "../../options";
-import { FirebaseAuth } from "@firebase/auth-types";
-import { User } from "firebase/app";
-
-export type FireApp = firebase.app.App;
+import {
+  FireApp,
+  FireAuth,
+  FireUser,
+  FireAuthUserCredentials,
+  FireStorage,
+  FireStore,
+  FireStoreTimeStamp,
+  FireStoragePutFileResult,
+  FireStoreCollectionRef,
+  FireStoreBatch
+} from "misc/firebase-models";
 
 export interface IFirebaseWrapper {
-  OnUserLogout(arg0: (user: firebase.User | null) => void): void;
-  init(firebaseConfig: {}, options: RAFirebaseOptions): void;
   options: RAFirebaseOptions;
-  db(): firebase.firestore.Firestore;
-  storage(): firebase.storage.Storage;
-  auth(): FirebaseAuth;
-  serverTimestamp(): any;
+  putFile(storagePath: string, rawFile: any): FireStoragePutFileResult;
+  getStorageDownloadUrl(fieldSrc: string): Promise<string>;
+  
+  dbGetCollection(absolutePath: string): FireStoreCollectionRef;
+  dbCreateBatch(): FireStoreBatch;
+  dbMakeNewId(): string;
+  
+  OnUserLogout(cb: (user: FireUser | null) => void): void;
+  authSetPersistence(persistenceInput: 'session' | 'local' | 'none'): Promise<void>;
+  authGetUserLoggedIn(): Promise<FireUser>;
+  authSigninEmailPassword(email: string, password: string): Promise<FireAuthUserCredentials>;
+  authSignOut(): Promise<void>;
+  serverTimestamp(): FireStoreTimeStamp | Date;
+
+  // Deprecated methods
+
+  /** @deprecated */
+  auth(): FireAuth;
+  /** @deprecated */
+  storage(): FireStorage;
+  /** @deprecated */
+  db(): FireStore;
+  /** @deprecated */
   GetApp(): FireApp;
-  GetUserLogin(): Promise<User>;
+  /** @deprecated */
+  GetUserLogin(): Promise<FireUser>;
 }

--- a/src/providers/lazy-loading/paramsToQuery.ts
+++ b/src/providers/lazy-loading/paramsToQuery.ts
@@ -1,8 +1,4 @@
-import {
-  CollectionReference,
-  OrderByDirection,
-  Query,
-} from '@firebase/firestore-types';
+import { FireStoreCollectionRef, FireStoreQuery, FireStoreQueryOrder } from 'misc/firebase-models';
 import { IFirestoreLogger, messageTypes } from '../../misc';
 import { findLastQueryCursor, getQueryCursor } from './queryCursors';
 
@@ -21,12 +17,12 @@ const defaultParamsToQueryOptions = {
 export async function paramsToQuery<
   TParams extends messageTypes.IParamsGetList
 >(
-  collection: CollectionReference,
+  collection: FireStoreCollectionRef,
   params: TParams,
   resourceName: string,
   flogger: IFirestoreLogger,
   options: ParamsToQueryOptions = defaultParamsToQueryOptions
-): Promise<Query> {
+): Promise<FireStoreQuery> {
   const filtersStepQuery = options.filters
     ? filtersToQuery(collection, params.filter)
     : collection;
@@ -47,9 +43,9 @@ export async function paramsToQuery<
 }
 
 export function filtersToQuery(
-  query: Query,
+  query: FireStoreQuery,
   filters: { [fieldName: string]: any }
-): Query {
+): FireStoreQuery {
   Object.keys(filters).forEach((fieldName) => {
     query = query.where(fieldName, '==', filters[fieldName]);
   });
@@ -57,24 +53,24 @@ export function filtersToQuery(
 }
 
 export function sortToQuery(
-  query: Query,
+  query: FireStoreQuery,
   sort: { field: string; order: string }
-): Query {
+): FireStoreQuery {
   if (sort != null && sort.field !== 'id') {
     const { field, order } = sort;
-    const parsedOrder = order.toLocaleLowerCase() as OrderByDirection;
+    const parsedOrder = order.toLocaleLowerCase() as FireStoreQueryOrder;
     query = query.orderBy(field, parsedOrder);
   }
   return query;
 }
 
 async function paginationToQuery<TParams extends messageTypes.IParamsGetList>(
-  query: Query,
+  query: FireStoreQuery,
   params: TParams,
-  collection: CollectionReference,
+  collection: FireStoreCollectionRef,
   resourceName: string,
   flogger: IFirestoreLogger
-): Promise<Query> {
+): Promise<FireStoreQuery> {
   const { page, perPage } = params.pagination;
   if (page === 1) {
     query = query.limit(perPage);

--- a/src/providers/lazy-loading/paramsToQuery.ts
+++ b/src/providers/lazy-loading/paramsToQuery.ts
@@ -46,10 +46,11 @@ export function filtersToQuery(
   query: FireStoreQuery,
   filters: { [fieldName: string]: any }
 ): FireStoreQuery {
-  Object.keys(filters).forEach((fieldName) => {
-    query = query.where(fieldName, '==', filters[fieldName]);
-  });
-  return query;
+  const res = Object.keys(filters).reduce((acc, fieldName) => {
+    acc.where(fieldName, '==', filters[fieldName]);
+    return acc;
+  }, query);
+  return res;
 }
 
 export function sortToQuery(
@@ -59,7 +60,7 @@ export function sortToQuery(
   if (sort != null && sort.field !== 'id') {
     const { field, order } = sort;
     const parsedOrder = order.toLocaleLowerCase() as FireStoreQueryOrder;
-    query = query.orderBy(field, parsedOrder);
+    return query.orderBy(field, parsedOrder);
   }
   return query;
 }

--- a/src/providers/lazy-loading/queryCursors.ts
+++ b/src/providers/lazy-loading/queryCursors.ts
@@ -1,12 +1,8 @@
-import {
-  CollectionReference,
-  DocumentSnapshot,
-  Query,
-} from '@firebase/firestore-types';
+import { FireStoreCollectionRef, FireStoreDocumentSnapshot, FireStoreQuery } from 'misc/firebase-models';
 import { IFirestoreLogger, messageTypes } from '../../misc';
 
 export function setQueryCursor(
-  doc: DocumentSnapshot,
+  doc: FireStoreDocumentSnapshot,
   params: messageTypes.IParamsGetList,
   resourceName: string
 ) {
@@ -25,11 +21,11 @@ export function setQueryCursor(
 }
 
 export async function getQueryCursor(
-  collection: CollectionReference,
+  collection: FireStoreCollectionRef,
   params: messageTypes.IParamsGetList,
   resourceName: string,
   flogger: IFirestoreLogger
-): Promise<DocumentSnapshot | false> {
+): Promise<FireStoreDocumentSnapshot | false> {
   const key = btoa(JSON.stringify({ ...params, resourceName }));
   const docId = localStorage.getItem(key);
   if (!docId) {
@@ -56,15 +52,15 @@ export function clearQueryCursors(resourceName: string) {
 }
 
 export async function findLastQueryCursor(
-  collection: CollectionReference,
-  queryBase: Query,
+  collection: FireStoreCollectionRef,
+  queryBase: FireStoreQuery,
   params: messageTypes.IParamsGetList,
   resourceName: string,
   flogger: IFirestoreLogger
 ) {
   const { page, perPage } = params.pagination;
 
-  let lastQueryCursor: DocumentSnapshot | false = false;
+  let lastQueryCursor: FireStoreDocumentSnapshot | false = false;
   let currentPage = page - 1;
 
   const currentPageParams = {

--- a/src/providers/options.ts
+++ b/src/providers/options.ts
@@ -1,8 +1,10 @@
+import { FireApp } from "misc/firebase-models";
+
 export interface RAFirebaseOptions {
   // Use a different root document to set your resource collections, by default it uses the root collections of firestore
   rootRef?: string | (() => string);
   // Your own, previously initialized firebase app instance
-  app?: any;
+  app?: FireApp;
   // Enable logging of react-admin-firebase
   logging?: boolean;
   // Resources to watch for realtime updates, will implicitly watch all resources by default, if not set.

--- a/src/providers/queries/GetManyReference.ts
+++ b/src/providers/queries/GetManyReference.ts
@@ -26,7 +26,7 @@ export async function GetManyReference<T extends ra.Record>(
     softDeleted = data.filter(doc => !doc['deleted'])
   }
   const filteredData = filterArray(softDeleted, filterSafe);
-  const targetIdFilter = {} as any;
+  const targetIdFilter: Record<string, ra.Identifier> = {};
   targetIdFilter[targetField] = targetValue;
   const permittedData = filterArray(filteredData, targetIdFilter);
   if (params.sort != null) {

--- a/tests/integration-tests/ApiCreate.spec.ts
+++ b/tests/integration-tests/ApiCreate.spec.ts
@@ -8,9 +8,9 @@ describe("ApiCreate", () => {
       disableMeta: true,
     });
     await Create("t1", { data: { name: "John" } }, client);
-    const users = await getDocsFromCollection(client.db(), "t1");
+    const users = await getDocsFromCollection(client.fireWrapper.db(), "t1");
     expect(users.length).toBe(1);
-    const first = users[0] as any;
+    const first = users[0];
     expect(first).toBeTruthy();
     expect(first.name).toBe("John");
   }, 100000);
@@ -22,7 +22,7 @@ describe("ApiCreate", () => {
       },
     });
     await Create("t1", { data: { name: "John" } }, client);
-    const users = await getDocsFromCollection(client.db(), "t1");
+    const users = await getDocsFromCollection(client.fireWrapper.db(), "t1");
     expect(users.length).toBe(1);
     const first = users[0] as {};
 

--- a/tests/integration-tests/ApiDelete.spec.ts
+++ b/tests/integration-tests/ApiDelete.spec.ts
@@ -7,7 +7,7 @@ describe("api methods", () => {
 
     const docId = "test123";
     const docObj = { id: docId, name: "Jim" };
-    await client.db().collection("t2").doc(docId).set(docObj);
+    await client.fireWrapper.dbGetCollection("t2").doc(docId).set(docObj);
 
     await Delete(
       "t2",
@@ -18,7 +18,7 @@ describe("api methods", () => {
       client
     );
 
-    const users = await getDocsFromCollection(client.db(), "t2");
+    const users = await getDocsFromCollection(client.fireWrapper.db(), "t2");
     expect(users.length).toBe(0);
   }, 100000);
 });

--- a/tests/integration-tests/ApiDeleteMany.spec.ts
+++ b/tests/integration-tests/ApiDeleteMany.spec.ts
@@ -6,7 +6,7 @@ describe("api methods", () => {
     const client = MakeMockClient();
     const docIds = ["test123", "test22222", "asdads"];
     const collName = "deleteables";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     await Promise.all(
       docIds.map((id) => collection.doc(id).set({ title: "ee" }))
     );

--- a/tests/integration-tests/ApiGetList.spec.ts
+++ b/tests/integration-tests/ApiGetList.spec.ts
@@ -1,12 +1,13 @@
 import { MakeMockClient } from "./utils/test-helpers";
 import { GetList } from "../../src/providers/queries";
+import { FireStoreCollectionRef } from "../../src/misc/firebase-models";
 
 describe("api methods", () => {
   test("FireClient list docs", async () => {
     const client = MakeMockClient();
     const docIds = ["test123", "test22222", "asdads"];
     const collName = "list-mes";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     await Promise.all(
       docIds.map((id) => collection.doc(id).set({ title: "ee" }))
     );
@@ -46,7 +47,7 @@ describe("api methods", () => {
       },
     ];
     const collName = "list-filtered";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     await Promise.all(testDocs.map((doc) => collection.add(doc)));
 
     const result = await GetList(
@@ -92,7 +93,7 @@ describe("api methods", () => {
       },
     ];
     const collName = "list-filtered";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     await Promise.all(testDocs.map((doc) => collection.add(doc)));
 
     const result = await GetList(
@@ -110,7 +111,7 @@ describe("api methods", () => {
       },
       client
     );
-    const second = result.data[1] as any;
+    const second = result.data[1];
     expect(second).toBeTruthy();
     expect(second.obj.title).toBe("B");
   }, 100000);
@@ -132,14 +133,14 @@ describe("api methods", () => {
       },
     ];
     const collName = "list-filtered";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     await Promise.all(testDocs.map((doc) => collection.add(doc)));
 
     const result = await GetList(
       collName,
       {
         filter: {
-          collectionQuery: (c: firebase.firestore.CollectionReference) =>
+          collectionQuery: (c: FireStoreCollectionRef) =>
             c.where("obj.volume", ">=", 100),
         },
         pagination: {
@@ -153,7 +154,7 @@ describe("api methods", () => {
       },
       client
     );
-    const third = result.data.length as any;
+    const third = result.data.length;
     expect(third).toBe(2);
   }, 100000);
 });

--- a/tests/integration-tests/ApiGetMany.spec.ts
+++ b/tests/integration-tests/ApiGetMany.spec.ts
@@ -6,7 +6,7 @@ describe("api methods", () => {
     const client = MakeMockClient();
     const docIds = ["test123", "test22222", "asdads"];
     const collName = "list-mes";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     await Promise.all(
       docIds.map((id) => collection.doc(id).set({ title: "ee" }))
     );

--- a/tests/integration-tests/ApiGetOne.spec.ts
+++ b/tests/integration-tests/ApiGetOne.spec.ts
@@ -6,7 +6,7 @@ describe("api methods", () => {
     const client = MakeMockClient();
     const docIds = ["test123", "test22222", "asdads"];
     const collName = "list-mes";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     await Promise.all(
       docIds.map((id) => collection.doc(id).set({ title: "ee" }))
     );
@@ -21,7 +21,7 @@ describe("api methods", () => {
     const client = MakeMockClient();
     const collName = "list-mes";
     const docId = "1234";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     const testDocNestedDates = {
       a: new Date("1999"),
       b: {
@@ -40,7 +40,7 @@ describe("api methods", () => {
       },
       client
     );
-    const data = result.data as any;
+    const data = result.data;
     expect(data).toBeTruthy();
     expect(data.a).toBeInstanceOf(Date);
     expect(data.b.b1).toBeInstanceOf(Date);

--- a/tests/integration-tests/ApiRootRef.spec.ts
+++ b/tests/integration-tests/ApiRootRef.spec.ts
@@ -5,8 +5,8 @@ describe("ApiRootRef", () => {
     const client = MakeMockClient({ rootRef: "root-ref1/ok" });
     const rm = client.rm;
     const docRef = await client
-      .db()
-      .collection("root-ref1/ok/t1")
+      .fireWrapper
+      .dbGetCollection("root-ref1/ok/t1")
       .add({ test: "" });
     const r = await rm.TryGetResourcePromise("t1");
     const snap = await r.collection.get();
@@ -18,8 +18,8 @@ describe("ApiRootRef", () => {
     const client = MakeMockClient({ rootRef: "root-ref-function1/ok" });
     const rm = client.rm;
     const docRef = await client
-      .db()
-      .collection("root-ref-function1/ok/t1")
+      .fireWrapper
+      .dbGetCollection("root-ref-function1/ok/t1")
       .add({ test: "" });
     const r = await rm.TryGetResourcePromise("t1");
     const snap = await r.collection.get();

--- a/tests/integration-tests/ApiSoftDelete.spec.ts
+++ b/tests/integration-tests/ApiSoftDelete.spec.ts
@@ -6,7 +6,7 @@ describe("api methods", () => {
     const client = MakeMockClient({ softDelete: true, disableMeta: true });
     const id = "test123";
     const collName = "t2";
-    const docRef = client.db().collection(collName).doc(id);
+    const docRef = client.fireWrapper.dbGetCollection(collName).doc(id);
     const docObj = { id, name: "Jim" };
     await docRef.set(docObj);
 

--- a/tests/integration-tests/ApiSoftDeleteMany.spec.ts
+++ b/tests/integration-tests/ApiSoftDeleteMany.spec.ts
@@ -6,7 +6,7 @@ describe("api methods", () => {
     const client = MakeMockClient({ softDelete: true, disableMeta: true });
     const docIds = ["test123", "test22222", "asdads"];
     const collName = "deleteables";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     await Promise.all(
       docIds.map((id) => collection.doc(id).set({ title: "ee" }))
     );

--- a/tests/integration-tests/ApiUpdate.spec.ts
+++ b/tests/integration-tests/ApiUpdate.spec.ts
@@ -6,7 +6,7 @@ describe("api methods", () => {
     const client = MakeMockClient({ disableMeta: true });
     const id = "testsss123";
     const collName = "t2";
-    const docRef = client.db().collection(collName).doc(id);
+    const docRef = client.fireWrapper.dbGetCollection(collName).doc(id);
     await docRef.set({ name: "Jim" });
 
     await Update(

--- a/tests/integration-tests/ApiUpdateMany.spec.ts
+++ b/tests/integration-tests/ApiUpdateMany.spec.ts
@@ -6,14 +6,14 @@ describe("api methods", () => {
     const client = MakeMockClient({ softDelete: true, disableMeta: true });
     const docIds = ["test123", "test22222", "asdads"];
     const collName = "updatec";
-    const collection = client.db().collection(collName);
+    const collection = client.fireWrapper.dbGetCollection(collName);
     await Promise.all(
       docIds.map((id) => collection.doc(id).set({ title: "ee" }))
     );
 
     await UpdateMany(
       collName,
-      { ids: docIds, data: { title: "blue" } as any },
+      { ids: docIds, data: { title: "blue" } },
       client
     );
     const res = await collection.get();

--- a/tests/integration-tests/utils/FirebaseWrapperStub.ts
+++ b/tests/integration-tests/utils/FirebaseWrapperStub.ts
@@ -1,40 +1,90 @@
 import { IFirebaseWrapper } from '../../../src/providers/database/firebase/IFirebaseWrapper';
 import { RAFirebaseOptions } from '../../../src/providers/options';
-import { firestore, User } from 'firebase';
 import * as firebase from "@firebase/testing";
+import {
+  FireApp,
+  FireAuth,
+  FireAuthUserCredentials,
+  FireStorage,
+  FireStoragePutFileResult,
+  FireStore,
+  FireStoreBatch,
+  FireStoreCollectionRef,
+  FireUploadTaskSnapshot, 
+  FireUser,
+} from '../../../src/misc/firebase-models';
 
 export class FirebaseWrapperStub implements IFirebaseWrapper {
-  private firestore: firestore.Firestore = null as any;
-  private app = null as any;
-  options: RAFirebaseOptions = null as any;
+  constructor(
+    private firestore: FireStore,
+    private app: FireApp,
+    public options: RAFirebaseOptions,
+  ) { }
+
+  dbGetCollection(absolutePath: string): FireStoreCollectionRef {
+    return this.firestore.collection(absolutePath);
+  }
+  dbCreateBatch(): FireStoreBatch {
+    return this.firestore.batch();
+  }
+  dbMakeNewId(): string {
+    return this.firestore.collection("collections").doc().id
+  }
+
+  public OnUserLogout(callBack: (u: FireUser) => any) {
+
+  }
+  putFile: any = async (storagePath: string, rawFile: any): Promise<FireStoragePutFileResult> => {
+    const task = this.app.storage().ref(storagePath).put(rawFile);
+    const taskResult = new Promise<FireUploadTaskSnapshot>(
+      (res, rej) => task.then(res).catch(rej)
+    );
+    const downloadUrl = taskResult.then(t => t.ref.getDownloadURL()).then(url => url as string)
+    return {
+      task,
+      taskResult,
+      downloadUrl,
+    };
+  }
+  async getStorageDownloadUrl(fieldSrc: string): Promise<string> {
+    return this.app.storage().ref(fieldSrc).getDownloadURL();
+  }
+  authSetPersistence(persistenceInput: 'session' | 'local' | 'none'): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  authGetUserLoggedIn(): Promise<FireUser> {
+    return { uid: "alice", email: 'alice@test.com' } as any;
+  }
+  authSigninEmailPassword(email: string, password: string): Promise<FireAuthUserCredentials> {
+    throw new Error('Method not implemented.');
+  }
+  authSignOut(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  serverTimestamp() {
+    return firebase.firestore.FieldValue.serverTimestamp();
+  }
+
+  // Deprecated methods
+
+  /** @deprecated */
+  auth(): FireAuth {
+    return this.app.auth();
+  }
+  /** @deprecated */
+  storage(): FireStorage {
+    return this.app.storage();
+  }
+  /** @deprecated */
+  db(): FireStore {
+    return this.firestore;
+  }
+  /** @deprecated */
   GetApp() {
     return this.app;
   }
-
-  constructor() {}
-
-  async GetUserLogin(): Promise<User> {
-    return { uid: "alice", email: 'alice@test.com' } as any;
-  }
-
-  public init(firebaseConfig: {}, options: RAFirebaseOptions): void {
-    this.options = options;
-    this.app = options.app;
-    this.firestore = this.app.firestore();
-  }
-  public db(): firestore.Firestore {
-    return this.firestore;
-  }
-  public auth() {
-    return this.app.auth();
-  }
-  storage() {
-    return this.app.storage();
-  }
-  public serverTimestamp() {
-    return firebase.firestore.FieldValue.serverTimestamp();
-  }
-  public OnUserLogout(callBack: (u: User) => any) {
-    
+  /** @deprecated */
+  GetUserLogin(): Promise<FireUser> {
+    return this.authGetUserLoggedIn();
   }
 }

--- a/tests/integration-tests/utils/test-helpers.ts
+++ b/tests/integration-tests/utils/test-helpers.ts
@@ -5,20 +5,20 @@ import { FirebaseWrapperStub } from "./FirebaseWrapperStub";
 import { RAFirebaseOptions } from "../../../src/providers/options";
 import { FireClient } from "../../../src/providers/database/FireClient";
 import { IFirestoreLogger } from '../../../src/misc';
-import { FireStore } from '../../../src/misc/firebase-models';
+import { FireApp, FireStore } from '../../../src/misc/firebase-models';
 
 function makeSafeId(projectId: string): string {
   return projectId.split(' ').join('').toLowerCase();
 }
 
-export class BlankLogger  implements IFirestoreLogger {
+export class BlankLogger implements IFirestoreLogger {
   logDocument = (count: number) => () => null;
   SetEnabled = (isEnabled: boolean) => null;
   ResetCount = (shouldReset: boolean) => null;
 }
 
 export function MakeMockClient(options: RAFirebaseOptions = {}) {
-  const randomProjectId = Math.random().toString(32).slice(2,10);
+  const randomProjectId = Math.random().toString(32).slice(2, 10);
   const fire = initFireWrapper(randomProjectId, options);
   return new FireClient(fire, options, new BlankLogger);
 }
@@ -28,8 +28,8 @@ export function initFireWrapper(projectId: string, rafOptions: RAFirebaseOptions
   const testOptions = { projectId: safeId };
   const app = firebase.initializeTestApp(testOptions);
   const fire: IFirebaseWrapper = new FirebaseWrapperStub(
-    app.firestore(),
-    app,
+    app.firestore() as FireStore,
+    app as FireApp,
     rafOptions,
   );
   return fire;
@@ -59,10 +59,10 @@ export async function getDocsFromCollection(
   const allDocs = await db.collection(collectionName).get();
   const docsData = await Promise.all(
     allDocs.docs.map((doc) =>
-      ({
-        ...doc.data(),
-        id: doc.id
-      }))
+    ({
+      ...doc.data(),
+      id: doc.id
+    }))
   );
   return docsData;
 }

--- a/tests/integration-tests/utils/test-helpers.ts
+++ b/tests/integration-tests/utils/test-helpers.ts
@@ -1,4 +1,3 @@
-import { FirebaseFirestore } from '@firebase/firestore-types';
 import * as firebase from '@firebase/testing';
 
 import { IFirebaseWrapper } from "../../../src/providers/database/firebase/IFirebaseWrapper";
@@ -6,6 +5,7 @@ import { FirebaseWrapperStub } from "./FirebaseWrapperStub";
 import { RAFirebaseOptions } from "../../../src/providers/options";
 import { FireClient } from "../../../src/providers/database/FireClient";
 import { IFirestoreLogger } from '../../../src/misc';
+import { FireStore } from '../../../src/misc/firebase-models';
 
 function makeSafeId(projectId: string): string {
   return projectId.split(' ').join('').toLowerCase();
@@ -26,9 +26,12 @@ export function MakeMockClient(options: RAFirebaseOptions = {}) {
 export function initFireWrapper(projectId: string, rafOptions: RAFirebaseOptions = {}): IFirebaseWrapper {
   const safeId = makeSafeId(projectId);
   const testOptions = { projectId: safeId };
-  const fire: IFirebaseWrapper = new FirebaseWrapperStub();
   const app = firebase.initializeTestApp(testOptions);
-  fire.init({}, { app: app, ...rafOptions });
+  const fire: IFirebaseWrapper = new FirebaseWrapperStub(
+    app.firestore(),
+    app,
+    rafOptions,
+  );
   return fire;
 }
 
@@ -41,7 +44,7 @@ export async function clearDb(projectId: string) {
 }
 
 export async function createDoc(
-  db: FirebaseFirestore,
+  db: FireStore,
   collectionName: string,
   docName: string,
   obj: {}
@@ -50,7 +53,7 @@ export async function createDoc(
 }
 
 export async function getDocsFromCollection(
-  db: FirebaseFirestore,
+  db: FireStore,
   collectionName: string
 ): Promise<any[]> {
   const allDocs = await db.collection(collectionName).get();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noImplicitAny": true,
     "esModuleInterop": true,
     "typeRoots": ["node_modules/@types", "src/types.d.ts"]
   },

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "typeRoots": ["node_modules/@types", "src/types.d.ts"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10183,15 +10183,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
 typescript@^3.9.5:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
-
-typescript@^4.1.x:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 uglify-js@^3.1.4:
   version "3.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,6 +969,11 @@
   resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.3.0.tgz#33c3f695313b561d48d18d663a20f20362d3ee7c"
   integrity sha512-0AJ6xn53Qn0D/YOVHHvlWFfnzzRSdd98Lr8Oqe1PJ2HPIN+o7qf03YmOG7fLpR1uplcWd+7vGKmxUrN3jKUBwg==
 
+"@firebase/analytics-types@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.3.1.tgz#3c5f5d71129c88295e17e914e34b391ffda1723c"
+  integrity sha512-63vVJ5NIBh/JF8l9LuPrQYSzFimk7zYHySQB4Dk9rVdJ8kV/vGQoVTvRu1UW05sEc2Ug5PqtEChtTHU+9hvPcA==
+
 "@firebase/analytics@0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.3.3.tgz#9f7d865a2c1d57fc4167a17a3122b5c46e35da12"
@@ -981,10 +986,40 @@
     "@firebase/util" "0.2.45"
     tslib "1.11.1"
 
+"@firebase/analytics@0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.4.2.tgz#b4869df9efc0334ae2fe3eba19b65b845a190012"
+  integrity sha512-WCoeUAO3lP6ikHJ3/XYptV90fpTidzTS9VpAfiVQK8gl9w1zvvKSavY9U3+EVG3frOPCFdE5DBO4MYrUw4gaqw==
+  dependencies:
+    "@firebase/analytics-types" "0.3.1"
+    "@firebase/component" "0.1.18"
+    "@firebase/installations" "0.4.16"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.1"
+    tslib "^1.11.1"
+
 "@firebase/app-types@0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.6.0.tgz#8dcc3e793c6983e9d54f7eb623a7618c05f2d94c"
   integrity sha512-ld6rzjXk/SUauHiQZJkeuSJpxIZ5wdnWuF5fWBFQNPaxsaJ9kyYg9GqEvwZ1z2e6JP5cU9gwRBlfW1WkGtGDYA==
+
+"@firebase/app-types@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.6.1.tgz#dcbd23030a71c0c74fc95d4a3f75ba81653850e9"
+  integrity sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==
+
+"@firebase/app@0.6.10":
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.6.10.tgz#520798f76906897284742b6eeb43257ec73f67a5"
+  integrity sha512-USg/AbgqBERhY0LayrKmmp7pka08WPa7OlFI46kaNW1pA2mUNf/ifTaxhCr2hGg/eWI0zPhpbEvtGQhSJ/QqWg==
+  dependencies:
+    "@firebase/app-types" "0.6.1"
+    "@firebase/component" "0.1.18"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.1"
+    dom-storage "2.1.0"
+    tslib "^1.11.1"
+    xmlhttprequest "1.8.0"
 
 "@firebase/app@0.6.2":
   version "0.6.2"
@@ -1004,10 +1039,20 @@
   resolved "https://registry.yarnpkg.com/@firebase/auth-interop-types/-/auth-interop-types-0.1.4.tgz#e81589f58508630a5bffa604d7c949a0d01ea97b"
   integrity sha512-CLKNS84KGAv5lRnHTQZFWoR11Ti7gIPFirDDXWek/fSU+TdYdnxJFR5XSD4OuGyzUYQ3Dq7aVj5teiRdyBl9hA==
 
+"@firebase/auth-interop-types@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz#9fc9bd7c879f16b8d1bb08373a0f48c3a8b74557"
+  integrity sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==
+
 "@firebase/auth-types@0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.10.0.tgz#9403633e723336055fad4bbf5e4c9fe3c55f8d3f"
   integrity sha512-VuW7c+RAk3AYPU0Hxmun3RzXn7fbJDdjQbxvvpRMnQ9zrhk8mH42cY466M0n4e/UGQ+0smlx5BqZII8aYQ5XPg==
+
+"@firebase/auth-types@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.10.1.tgz#7815e71c9c6f072034415524b29ca8f1d1770660"
+  integrity sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw==
 
 "@firebase/auth@0.14.3":
   version "0.14.3"
@@ -1015,6 +1060,13 @@
   integrity sha512-XPB3Mf3PwHibv2HbvqOol02ACCuwAKSY9HAtq70w3K3OwSDX4opDdrNOhoer7Nrq3xvX58b+c+oVGxD9mbo/qQ==
   dependencies:
     "@firebase/auth-types" "0.10.0"
+
+"@firebase/auth@0.14.9":
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.14.9.tgz#481db24d5bd6eded8ac2e5aea6edb9307040229c"
+  integrity sha512-PxYa2r5qUEdheXTvqROFrMstK8W4uPiP7NVfp+2Bec+AjY5PxZapCx/YFDLkU0D7YBI82H74PtZrzdJZw7TJ4w==
+  dependencies:
+    "@firebase/auth-types" "0.10.1"
 
 "@firebase/component@0.1.10":
   version "0.1.10"
@@ -1024,12 +1076,27 @@
     "@firebase/util" "0.2.45"
     tslib "1.11.1"
 
+"@firebase/component@0.1.18":
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.1.18.tgz#28e69e54b79953376283464cb0543bde4c104140"
+  integrity sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==
+  dependencies:
+    "@firebase/util" "0.3.1"
+    tslib "^1.11.1"
+
 "@firebase/database-types@0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.5.0.tgz#603a0865c3180a9ffb6f5fa065d156387385a74d"
   integrity sha512-6/W3frFznYOALtw2nrWVPK2ytgdl89CzTqVBHCCGf22wT6uKU63iDBo+Nw+7olFGpD15O0zwYalFIcMZ27tkew==
   dependencies:
     "@firebase/app-types" "0.6.0"
+
+"@firebase/database-types@0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.5.2.tgz#23bec8477f84f519727f165c687761e29958b63c"
+  integrity sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==
+  dependencies:
+    "@firebase/app-types" "0.6.1"
 
 "@firebase/database@0.6.1":
   version "0.6.1"
@@ -1044,15 +1111,33 @@
     faye-websocket "0.11.3"
     tslib "1.11.1"
 
+"@firebase/database@0.6.11":
+  version "0.6.11"
+  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-0.6.11.tgz#74a09d5f4769eb97c00bc2f7621f54efbccea6f2"
+  integrity sha512-QOHhB7+CdjVhEXG9CyX0roA9ARJcEuwbozz0Bix+ULuZqjQ58KUFHMH1apW6EEiUP22d/mYD7dNXsUGshjL9PA==
+  dependencies:
+    "@firebase/auth-interop-types" "0.1.5"
+    "@firebase/component" "0.1.18"
+    "@firebase/database-types" "0.5.2"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.1"
+    faye-websocket "0.11.3"
+    tslib "^1.11.1"
+
 "@firebase/firestore-types@1.10.1":
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-1.10.1.tgz#bf018f9c495f470592de745389474dc1c2960d3f"
   integrity sha512-vyKdm+AYUFT8XeUX62IOqaqPFCs/mAMoSEsqIz9HnSVsqCw/IocNjtjSa+3M80kRw4V8fI7JI+Xz6Wg5VJXLqA==
 
-"@firebase/firestore-types@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-1.2.0.tgz#1a0e8c80c80c8e65b116a246cd0b5acfd2b11dc6"
-  integrity sha512-ArgiKhbszYxEuApxwU1H7EiNSubEX+wDab4h9WMOh7dwvgyZG43XbTvYqKdBTsqmrNWHJtEEPTuArD3BndzMlQ==
+"@firebase/firestore-types@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-1.12.0.tgz#511e572e946b07f5a603c90e078f0cd714923fac"
+  integrity sha512-OqNxVb63wPZdUc7YnpacAW1WNIMSKERSewCRi+unCQ0YI0KNfrDSypyGCyel+S3GdOtKMk9KnvDknaGbnaFX4g==
+
+"@firebase/firestore-types@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-2.5.0.tgz#16fca40b6980fdb000de86042d7a96635f2bcdd7"
+  integrity sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==
 
 "@firebase/firestore@1.14.1":
   version "1.14.1"
@@ -1068,10 +1153,30 @@
     "@grpc/proto-loader" "^0.5.0"
     tslib "1.11.1"
 
+"@firebase/firestore@1.16.4":
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-1.16.4.tgz#29cb121f5686cab6e310bf16a1094f06f3678385"
+  integrity sha512-Ur+I8a8RkkbbJRsebkYAUwKFkbh9FemDxTFD/2Vp01pAPM8S3MoIcVegAfTvnPlG/ObBq5O7wI4CRA6b/G/Iyg==
+  dependencies:
+    "@firebase/component" "0.1.18"
+    "@firebase/firestore-types" "1.12.0"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.1"
+    "@firebase/webchannel-wrapper" "0.3.0"
+    "@grpc/grpc-js" "^1.0.0"
+    "@grpc/proto-loader" "^0.5.0"
+    node-fetch "2.6.0"
+    tslib "^1.11.1"
+
 "@firebase/functions-types@0.3.16":
   version "0.3.16"
   resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.3.16.tgz#be0362d7f61648fdf36a7d95de239eddee88f931"
   integrity sha512-kHhBvSYiY2prY4vNQCALYs1+OruTdylvGemHG6G6Bs/rj3qw7ui3WysBsDU/rInJitHIcsZ35qrtanoJeQUIXQ==
+
+"@firebase/functions-types@0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.3.17.tgz#348bf5528b238eeeeeae1d52e8ca547b21d33a94"
+  integrity sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ==
 
 "@firebase/functions@0.4.41":
   version "0.4.41"
@@ -1084,10 +1189,37 @@
     isomorphic-fetch "2.2.1"
     tslib "1.11.1"
 
+"@firebase/functions@0.4.50":
+  version "0.4.50"
+  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.4.50.tgz#02ae1a2a42de9c4c73f13c00043dbba6546248a0"
+  integrity sha512-eBsNrUm/Jfc/xsQXmxQRSkEg6pwHlMd2hice8N90/EeqgwqS/SCvC+O9cJITLlXroAghb9jWDWRvAkDU/TOhpw==
+  dependencies:
+    "@firebase/component" "0.1.18"
+    "@firebase/functions-types" "0.3.17"
+    "@firebase/messaging-types" "0.5.0"
+    isomorphic-fetch "2.2.1"
+    tslib "^1.11.1"
+
 "@firebase/installations-types@0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@firebase/installations-types/-/installations-types-0.3.3.tgz#f2e49e73afaeb7b352250365d0d90dff0b792592"
   integrity sha512-XvWhPPAGeZlc+CfCA8jTt2pv19Jovi/nUV73u30QbjBbk5xci9bp5I29aBZukHsR6YNBjFCLSkLPbno4m/bLUg==
+
+"@firebase/installations-types@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@firebase/installations-types/-/installations-types-0.3.4.tgz#589a941d713f4f64bf9f4feb7f463505bab1afa2"
+  integrity sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q==
+
+"@firebase/installations@0.4.16":
+  version "0.4.16"
+  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.4.16.tgz#5c3f2e542308f06439aeddb0f456f3f36ae808eb"
+  integrity sha512-gqv3IrBUmPWKpH8wLJ0fZcAH1NEXwQhqjqnK3cQXRcIkEARP430cmIAaj7CcPdgdemHX9HqwJG+So/yBHIYXPA==
+  dependencies:
+    "@firebase/component" "0.1.18"
+    "@firebase/installations-types" "0.3.4"
+    "@firebase/util" "0.3.1"
+    idb "3.0.2"
+    tslib "^1.11.1"
 
 "@firebase/installations@0.4.8":
   version "0.4.8"
@@ -1105,10 +1237,20 @@
   resolved "https://registry.yarnpkg.com/@firebase/logger/-/logger-0.2.2.tgz#aea3ef8cbb131c9d3daaf8022f120f194a40509f"
   integrity sha512-MbEy17Ha1w/DlLtvxG89ScQ+0+yoElGKJ1nUCQHHLjeMNsRwd2wnUPOVCsZvtBzQp8Z0GaFmD4a2iG2v91lEbA==
 
+"@firebase/logger@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@firebase/logger/-/logger-0.2.6.tgz#3aa2ca4fe10327cabf7808bd3994e88db26d7989"
+  integrity sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==
+
 "@firebase/messaging-types@0.4.4":
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/@firebase/messaging-types/-/messaging-types-0.4.4.tgz#bef66157bdd3ddaafd6d48f1c5ee973fdc385f84"
   integrity sha512-JGtkr+1A1Dw7+yCqQigqBfGKtq0gTCruFScBD4MVjqZHiqGIYpnQisWnpGbkzPR6aOt6iQxgwxUhHG1ulUQGeg==
+
+"@firebase/messaging-types@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging-types/-/messaging-types-0.5.0.tgz#c5d0ef309ced1758fda93ef3ac70a786de2e73c4"
+  integrity sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==
 
 "@firebase/messaging@0.6.13":
   version "0.6.13"
@@ -1122,10 +1264,27 @@
     idb "3.0.2"
     tslib "1.11.1"
 
+"@firebase/messaging@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.7.0.tgz#6932f6bfcc04148891751aecce426cafe76e0a06"
+  integrity sha512-PTD5pQw9QremOjiWWZYOkzcX6OKByMvlG+NQXdTnyL3kLbE01Bdp9iWhkH6ipNpHYMiwcK1RZD4TLkYVBviBsw==
+  dependencies:
+    "@firebase/component" "0.1.18"
+    "@firebase/installations" "0.4.16"
+    "@firebase/messaging-types" "0.5.0"
+    "@firebase/util" "0.3.1"
+    idb "3.0.2"
+    tslib "^1.11.1"
+
 "@firebase/performance-types@0.0.12":
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@firebase/performance-types/-/performance-types-0.0.12.tgz#15fa79e296b502e21054a66c9e7ded59398fd8a7"
   integrity sha512-eIDF7CHetOE5sc+hCaUebEn/2Aiaju7UkgZDTl7lNQHz5fK9wJ/11HaE8WdnDr//ngS3lQAGC2RB4lAZeEWraA==
+
+"@firebase/performance-types@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@firebase/performance-types/-/performance-types-0.0.13.tgz#58ce5453f57e34b18186f74ef11550dfc558ede6"
+  integrity sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==
 
 "@firebase/performance@0.3.1":
   version "0.3.1"
@@ -1139,6 +1298,18 @@
     "@firebase/util" "0.2.45"
     tslib "1.11.1"
 
+"@firebase/performance@0.3.11":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.3.11.tgz#833c8abe5f5554f25545c8d28b487d8ac3ff3f95"
+  integrity sha512-L00vBUa2zzoSSOq3StTN43fPxtJ+myF+t+2kP5bQGHN5WOmf22lIsuEjAy1FAscDjVjhL1k5rKMY332ZwEfblg==
+  dependencies:
+    "@firebase/component" "0.1.18"
+    "@firebase/installations" "0.4.16"
+    "@firebase/logger" "0.2.6"
+    "@firebase/performance-types" "0.0.13"
+    "@firebase/util" "0.3.1"
+    tslib "^1.11.1"
+
 "@firebase/polyfill@0.3.34":
   version "0.3.34"
   resolved "https://registry.yarnpkg.com/@firebase/polyfill/-/polyfill-0.3.34.tgz#d28394b946da4b883e086fbf2bb065b47b7a86c5"
@@ -1148,10 +1319,24 @@
     promise-polyfill "8.1.3"
     whatwg-fetch "2.0.4"
 
+"@firebase/polyfill@0.3.36":
+  version "0.3.36"
+  resolved "https://registry.yarnpkg.com/@firebase/polyfill/-/polyfill-0.3.36.tgz#c057cce6748170f36966b555749472b25efdb145"
+  integrity sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==
+  dependencies:
+    core-js "3.6.5"
+    promise-polyfill "8.1.3"
+    whatwg-fetch "2.0.4"
+
 "@firebase/remote-config-types@0.1.8":
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/@firebase/remote-config-types/-/remote-config-types-0.1.8.tgz#0c8d8a839621230053ba55704b5d1145bfe54daa"
   integrity sha512-K12IBHO7OD4gCW0FEqZL9zMqVAfS4+joC4YIn3bHezZfu3RL+Bw1wCb0cAD7RfDPcQxWJjxOHpce4YhuqSxPFA==
+
+"@firebase/remote-config-types@0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz#fe6bbe4d08f3b6e92fce30e4b7a9f4d6a96d6965"
+  integrity sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA==
 
 "@firebase/remote-config@0.1.19":
   version "0.1.19"
@@ -1165,10 +1350,27 @@
     "@firebase/util" "0.2.45"
     tslib "1.11.1"
 
+"@firebase/remote-config@0.1.27":
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config/-/remote-config-0.1.27.tgz#b581cb7d870e7d32bac5967acbbb5d7ec593a2f3"
+  integrity sha512-BGjmQomRKNf+yGJ/3/5Kw6zNLM5jY9oTVjLmYsQXf6U+HMgz6J2H6EVGc1bZW7YSsvak8f6DomxegQtvfvwaMw==
+  dependencies:
+    "@firebase/component" "0.1.18"
+    "@firebase/installations" "0.4.16"
+    "@firebase/logger" "0.2.6"
+    "@firebase/remote-config-types" "0.1.9"
+    "@firebase/util" "0.3.1"
+    tslib "^1.11.1"
+
 "@firebase/storage-types@0.3.11":
   version "0.3.11"
   resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.3.11.tgz#98f6ced5460502ab12778ce71d4dc9bf0ab7f2ee"
   integrity sha512-EMOo5aeiJIa8eQ/VqjIa/DYlDcEJX1V84FOxmLfNWZIlmCSvcqx9E9mcNlOnoUB4iePqQjTMQRtKlIBvvEVhVg==
+
+"@firebase/storage-types@0.3.13":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.3.13.tgz#cd43e939a2ab5742e109eb639a313673a48b5458"
+  integrity sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==
 
 "@firebase/storage@0.3.32":
   version "0.3.32"
@@ -1180,15 +1382,24 @@
     "@firebase/util" "0.2.45"
     tslib "1.11.1"
 
-"@firebase/testing@^0.19.1":
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/@firebase/testing/-/testing-0.19.1.tgz#a6703701bd80554c2720d2cfa4c12ae6c7109efc"
-  integrity sha512-uTqgjJlv4KLio6a5GxwhUL4rPefqoPR7uAaqdE4AETZBVj7shCq/E+Qy613oFlbtrWdUNhKW5vFBZkKWjLrKVQ==
+"@firebase/storage@0.3.42":
+  version "0.3.42"
+  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.3.42.tgz#e2fe1aa54c004852a848b50f34c2f351e6e517e5"
+  integrity sha512-FqHDWZPhATQeOFBQUZPsQO7xhnGBxprYVDb9eIjCnh1yRl6WAv/OQGHOF+JU5+H+YkjsKTtr/5VjyDl3Y0UHxw==
   dependencies:
-    "@firebase/logger" "0.2.2"
-    "@firebase/util" "0.2.45"
-    "@types/request" "2.48.4"
-    firebase "7.14.1"
+    "@firebase/component" "0.1.18"
+    "@firebase/storage-types" "0.3.13"
+    "@firebase/util" "0.3.1"
+    tslib "^1.11.1"
+
+"@firebase/testing@^0.20.11":
+  version "0.20.11"
+  resolved "https://registry.yarnpkg.com/@firebase/testing/-/testing-0.20.11.tgz#ebb7e987abbcc4f1b3c3e1922b90333ed529d866"
+  integrity sha512-cXu3B4NDG1HbmZby/lxaY7zAWdrhX/HzTzTkk15d3IJ0v+JlBHBWE8y8969UquoGv6fVcbTstUqMX3jgCRcfuw==
+  dependencies:
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.1"
+    firebase "7.18.0"
     request "2.88.2"
 
 "@firebase/util@0.2.45":
@@ -1198,10 +1409,22 @@
   dependencies:
     tslib "1.11.1"
 
+"@firebase/util@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-0.3.1.tgz#8c95152a00121bd31fb7c1fc6520ca208976e384"
+  integrity sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==
+  dependencies:
+    tslib "^1.11.1"
+
 "@firebase/webchannel-wrapper@0.2.39":
   version "0.2.39"
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.39.tgz#32ce49e0ba54d831750afde59e32889bef444fd3"
   integrity sha512-V5oQjtYxHlEpWdQr68ZFo8T+3NVccrTieRy8RnzYIasCeptxOxwYUG0cAAKmalgrrrfRJdXup8h5ybi3XSW9Hw==
+
+"@firebase/webchannel-wrapper@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.3.0.tgz#d1689566b94c25423d1fb2cb031c5c2ea4c9f939"
+  integrity sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ==
 
 "@google-cloud/paginator@^2.0.0":
   version "2.0.3"
@@ -1268,6 +1491,14 @@
   dependencies:
     semver "^6.2.0"
 
+"@grpc/grpc-js@^1.0.0":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.5.3.tgz#fe78a40eab4e21a6044ff6f23798f712ea352a8f"
+  integrity sha512-q0xgaZ3ymUM+ZOhe1hdocVSdKHCnJ6llLSXcP+MqMXMyYPUZ3mzQOCxZ3Zkg+QZ7sZ950sn7hvueQrIJZumPZg==
+  dependencies:
+    "@grpc/proto-loader" "^0.6.4"
+    "@types/node" ">=12.12.47"
+
 "@grpc/proto-loader@^0.5.0", "@grpc/proto-loader@^0.5.1":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.5.4.tgz#038a3820540f621eeb1b05d81fbedfb045e14de0"
@@ -1275,6 +1506,17 @@
   dependencies:
     lodash.camelcase "^4.3.0"
     protobufjs "^6.8.6"
+
+"@grpc/proto-loader@^0.6.4":
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.6.9.tgz#4014eef366da733f8e04a9ddd7376fe8a58547b7"
+  integrity sha512-UlcCS8VbsU9d3XTXGiEVFonN7hXk+oMXZtoHHG2oSA1/GcDP1q6OUgs20PzHDGizzyi8ufGSUDlk3O2NyY7leg==
+  dependencies:
+    "@types/long" "^4.0.1"
+    lodash.camelcase "^4.3.0"
+    long "^4.0.0"
+    protobufjs "^6.10.0"
+    yargs "^16.2.0"
 
 "@jest/types@^24.9.0":
   version "24.9.0"
@@ -1417,11 +1659,6 @@
     "@babel/runtime" "^7.5.5"
     "@testing-library/dom" "^5.6.1"
 
-"@types/caseless@*":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
-  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
-
 "@types/duplexify@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@types/duplexify/-/duplexify-3.6.0.tgz#dfc82b64bd3a2168f5bd26444af165bf0237dcd8"
@@ -1490,7 +1727,7 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
   integrity sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==
 
-"@types/long@^4.0.0":
+"@types/long@^4.0.0", "@types/long@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
@@ -1499,6 +1736,11 @@
   version "13.13.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.0.tgz#30d2d09f623fe32cde9cb582c7a6eda2788ce4a8"
   integrity sha512-WE4IOAC6r/yBZss1oQGM5zs2D7RuKR6Q+w+X2SouPofnWn+LbCqClRyhO3ZE7Ix8nmFgo/oVuuE01cJT2XB13A==
+
+"@types/node@>=12.12.47", "@types/node@>=13.7.0":
+  version "17.0.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.10.tgz#616f16e9d3a2a3d618136b1be244315d95bd7cab"
+  integrity sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==
 
 "@types/node@^10.1.0", "@types/node@^10.9.4":
   version "10.17.20"
@@ -1552,16 +1794,6 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
-
-"@types/request@2.48.4":
-  version "2.48.4"
-  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.4.tgz#df3d43d7b9ed3550feaa1286c6eabf0738e6cf7e"
-  integrity sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==
-  dependencies:
-    "@types/caseless" "*"
-    "@types/node" "*"
-    "@types/tough-cookie" "*"
-    form-data "^2.5.0"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -1670,11 +1902,6 @@
     "@types/rx-lite-testing" "*"
     "@types/rx-lite-time" "*"
     "@types/rx-lite-virtualtime" "*"
-
-"@types/tough-cookie@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
-  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -1801,6 +2028,11 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -1813,7 +2045,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -2818,6 +3050,15 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
@@ -3724,6 +3965,11 @@ electron-to-chromium@^1.3.591:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.603.tgz#1b71bec27fb940eccd79245f6824c63d5f7e8abf"
   integrity sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
@@ -4386,7 +4632,7 @@ firebase-tools@^8.1.1:
     winston "^3.0.0"
     ws "^7.2.3"
 
-firebase@*, firebase@7.14.1, firebase@^7.9.1:
+firebase@*, firebase@^7.9.1:
   version "7.14.1"
   resolved "https://registry.yarnpkg.com/firebase/-/firebase-7.14.1.tgz#62326774e9d82b0a7ac2763f6c644f5799b8b8a5"
   integrity sha512-2lgBgWuFOd9wnwgOQEKmqqxuWf2Cp2xw08Nwar8/fD5gtoMngn7JY2PE86VUSu7XVTyhVFLfAIAMyZLDaRRTOg==
@@ -4405,6 +4651,26 @@ firebase@*, firebase@7.14.1, firebase@^7.9.1:
     "@firebase/remote-config" "0.1.19"
     "@firebase/storage" "0.3.32"
     "@firebase/util" "0.2.45"
+
+firebase@7.18.0:
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-7.18.0.tgz#00e3967f5bc608f3e12c1a5f0192f559de87943e"
+  integrity sha512-RGq0rWX25EDsM21TjRe1FbnygJwHXL7yN4P0Zh2Z7dWrBcfJ8tQpDxgwMDtiJTuo9UYExK3py4wjgpGJBau6wg==
+  dependencies:
+    "@firebase/analytics" "0.4.2"
+    "@firebase/app" "0.6.10"
+    "@firebase/app-types" "0.6.1"
+    "@firebase/auth" "0.14.9"
+    "@firebase/database" "0.6.11"
+    "@firebase/firestore" "1.16.4"
+    "@firebase/functions" "0.4.50"
+    "@firebase/installations" "0.4.16"
+    "@firebase/messaging" "0.7.0"
+    "@firebase/performance" "0.3.11"
+    "@firebase/polyfill" "0.3.36"
+    "@firebase/remote-config" "0.1.27"
+    "@firebase/storage" "0.3.42"
+    "@firebase/util" "0.3.1"
 
 first-chunk-stream@^1.0.0:
   version "1.0.0"
@@ -4449,15 +4715,6 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
-
-form-data@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -4602,6 +4859,11 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -5523,6 +5785,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
@@ -7377,6 +7644,11 @@ node-emoji@^1.4.1:
   dependencies:
     lodash.toarray "^4.4.0"
 
+node-fetch@2.6.0, node-fetch@^2.3.0, node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -7384,11 +7656,6 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
-
-node-fetch@^2.3.0, node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-forge@^0.9.0:
   version "0.9.1"
@@ -8494,6 +8761,25 @@ prop-types@^15.6.1:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+protobufjs@^6.10.0:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
+  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
+
 protobufjs@^6.8.1, protobufjs@^6.8.6, protobufjs@^6.8.8, protobufjs@^6.8.9:
   version "6.8.9"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.9.tgz#0b1adbcdaa983d369c3d9108a97c814edc030754"
@@ -9596,6 +9882,15 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.trimend@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
@@ -9669,6 +9964,13 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@3.0.0:
   version "3.0.0"
@@ -10098,7 +10400,7 @@ tslib@1.11.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^1.13.0:
+tslib@^1.11.1, tslib@^1.13.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -10625,6 +10927,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -10701,6 +11012,11 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -10723,6 +11039,11 @@ yargs-parser@18.x:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-parser@^9.0.2:
   version "9.0.2"
@@ -10748,6 +11069,19 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 zip-stream@^2.1.2:
   version "2.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,11 +986,6 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.6.0.tgz#8dcc3e793c6983e9d54f7eb623a7618c05f2d94c"
   integrity sha512-ld6rzjXk/SUauHiQZJkeuSJpxIZ5wdnWuF5fWBFQNPaxsaJ9kyYg9GqEvwZ1z2e6JP5cU9gwRBlfW1WkGtGDYA==
 
-"@firebase/app-types@^0.3.9":
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.3.10.tgz#8f6d24d80bf833622b53ed26eaa04cfa9dd0f2f3"
-  integrity sha512-l+5BJtSQopalBXiY/YuSaB9KF9PnDj37FLV0Sx3qJjh5B3IthCuZbPc1Vpbbbee/QZgudl0G212BBsUMGHP+fQ==
-
 "@firebase/app@0.6.2":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.6.2.tgz#ecdd0ab743151bdbfedf2461b96e3a3b58e51a0a"
@@ -1013,11 +1008,6 @@
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.10.0.tgz#9403633e723336055fad4bbf5e4c9fe3c55f8d3f"
   integrity sha512-VuW7c+RAk3AYPU0Hxmun3RzXn7fbJDdjQbxvvpRMnQ9zrhk8mH42cY466M0n4e/UGQ+0smlx5BqZII8aYQ5XPg==
-
-"@firebase/auth-types@^0.6.0":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.6.1.tgz#9b60142e3a4adc1db09c037d068ab98cd54c10a8"
-  integrity sha512-uciPeIQJC1NZDhI5+BWbyqi70YXIjT3jm03sYtIgkPt2sr3n8sq1RpnoTMYfAJkQ0QlgLaBkeM/huMx06eBoXQ==
 
 "@firebase/auth@0.14.3":
   version "0.14.3"
@@ -1201,7 +1191,7 @@
     firebase "7.14.1"
     request "2.88.2"
 
-"@firebase/util@0.2.45", "@firebase/util@^0.2.11":
+"@firebase/util@0.2.45":
   version "0.2.45"
   resolved "https://registry.yarnpkg.com/@firebase/util/-/util-0.2.45.tgz#d52f28da8a4d7a4fa97d36202a86d5f654fbed6d"
   integrity sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==


### PR DESCRIPTION
- No features added
- Centralises firebase types in `src/misc/firebase-models.ts`
- Removes dependencies on random parts of the SDK
- Should make upgrading the firebase SDK much easier