### PR TITLE
Fix storage relative paths

### DIFF
--- a/src/misc/translate-from-firestore.ts
+++ b/src/misc/translate-from-firestore.ts
@@ -129,11 +129,12 @@ export const recursivelyMapStorageUrls = async (
   }
   const isObject = !isArray && typeof fieldValue === "object";
   if (isObject) {
-    return Promise.all(
+    await Promise.all(
       Object.keys(fieldValue).map(async (key) => {
         const value = fieldValue[key];
         fieldValue[key] = await recursivelyMapStorageUrls(fireWrapper, value);
       })
     );
+    return fieldValue;
   }
 };


### PR DESCRIPTION
`GetList` expects `object`, but receives `array` of `undefineds`. This simple fix returns the expected object.

Before:
<img width="848" alt="image" src="https://user-images.githubusercontent.com/6765023/206015822-833552ec-7e2e-4f76-ab5f-4aa3831acfd9.png">

After
<img width="847" alt="image" src="https://user-images.githubusercontent.com/6765023/206016245-2245a75e-f33f-4079-a741-31498becd191.png">


closes #250