### PR TITLE
Better filtering for string filters

### DIFF
--- a/src/providers/lazy-loading/paramsToQuery.ts
+++ b/src/providers/lazy-loading/paramsToQuery.ts
@@ -74,7 +74,12 @@ export function getFiltersConstraints(filters: {
 }): QueryConstraint[] {
   return Object.entries(filters).flatMap(([fieldName, fieldValue]) => {
     if (Array.isArray(fieldValue)) {
-      return [where(fieldName, 'in', fieldValue)];
+      return [where(fieldName, 'array-contains-any', fieldValue)];
+    } else if (Object.keys(filters).length === 1 && isNaN(fieldValue)) {
+      return [
+        where(fieldName, '>=', fieldValue),
+        where(fieldName, '<', fieldValue + 'z'),
+      ];
     } else {
       return [where(fieldName, '==', fieldValue)];
     }

--- a/tests/providers/lazy-loading/paramsToQuery.spec.ts
+++ b/tests/providers/lazy-loading/paramsToQuery.spec.ts
@@ -1,0 +1,56 @@
+import { getFiltersConstraints } from '../../../src/providers/lazy-loading/paramsToQuery';
+import { QueryConstraintType } from '@firebase/firestore';
+
+describe('getFiltersConstraints', () => {
+  it('should return where filter with array-contains-any operator when filter value is array', () => {
+    const filters = { fieldA: ['valueA'] };
+
+    const result = getFiltersConstraints(filters);
+
+    expect(result.length).toEqual(1);
+    const queryConstraint = result[0];
+    expect(queryConstraint.type).toEqual('where' as QueryConstraintType);
+    // @ts-ignore
+    expect(queryConstraint['_op']).toEqual('array-contains-any');
+  });
+
+  it('should return two where filters when filter value is string', () => {
+    const filters = { fieldA: 'valueA' };
+
+    const result = getFiltersConstraints(filters);
+
+    expect(result.length).toEqual(2);
+    const queryConstraintGte = result[0];
+    const queryConstraintLt = result[1];
+    expect(queryConstraintGte.type).toEqual('where' as QueryConstraintType);
+    expect(queryConstraintLt.type).toEqual('where' as QueryConstraintType);
+    // @ts-ignore
+    expect(queryConstraintGte['_op']).toEqual('>=');
+    // @ts-ignore
+    expect(queryConstraintLt['_op']).toEqual('<');
+  });
+
+  it('should return where filter with == operator when field value is number', () => {
+    const filters = { fieldA: 1 };
+
+    const result = getFiltersConstraints(filters);
+
+    expect(result.length).toEqual(1);
+    const queryConstraint = result[0];
+    expect(queryConstraint.type).toEqual('where' as QueryConstraintType);
+    // @ts-ignore
+    expect(queryConstraint['_op']).toEqual('==');
+  });
+
+  it('should return where filter with == operator when field value is boolean', () => {
+    const filters = { fieldA: false };
+
+    const result = getFiltersConstraints(filters);
+
+    expect(result.length).toEqual(1);
+    const queryConstraint = result[0];
+    expect(queryConstraint.type).toEqual('where' as QueryConstraintType);
+    // @ts-ignore
+    expect(queryConstraint['_op']).toEqual('==');
+  });
+});


### PR DESCRIPTION
Filtering for string values was performed by exact match. This PR uses gte and lt filters for comparing strings, that will match the results with partial values