### PR TITLE
Refactor AuthProvider to throw original error

### DIFF
--- a/src/providers/AuthProvider.ts
+++ b/src/providers/AuthProvider.ts
@@ -34,9 +34,14 @@ class AuthClient {
         );
         log('HandleAuthLogin: user sucessfully logged in', { user });
         return user;
-      } catch (e) {
-        log('HandleAuthLogin: invalid credentials', { params });
-        throw e;
+      } catch (e: any) {
+        if (e.code == 'auth/multi-factor-auth-required') {
+          log('HandleAuthLogin: second factor challenge required', { params });
+          throw e;
+        } else {
+          log('HandleAuthLogin: invalid credentials', { params });
+          throw new Error('Login error: invalid credentials');
+        }
       }
     } else {
       return this.getUserLogin();

--- a/src/providers/AuthProvider.ts
+++ b/src/providers/AuthProvider.ts
@@ -36,7 +36,7 @@ class AuthClient {
         return user;
       } catch (e) {
         log('HandleAuthLogin: invalid credentials', { params });
-        throw new Error('Login error: invalid credentials');
+        throw e;
       }
     } else {
       return this.getUserLogin();


### PR DESCRIPTION
Refactors the AuthProvider to throw the original error instead of a generic 'Login error: invalid credentials' error when dealing with Multi-Factor users.

This allows access to the `error code` and `resolver` needed for MFA sign ins.

References:
https://firebase.google.com/docs/reference/node/firebase.auth.multifactorerror https://firebase.google.com/docs/auth/web/multi-factor#signing_users_in_with_a_second_factor